### PR TITLE
Fix hyperlink in 'docs/README.md' (#10)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,5 @@
 | File / Section                                                               | Description                                                                                                   |
 |------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | **[setup.md](setup.md)** | Environment setup and tools|
-| **[contribution.md](data.md)** | Contribution rules|
+| **[contribution.md](contribution.md)** | Contribution rules|
 | **[data.md](data.md)** | Data structure and processing|


### PR DESCRIPTION
## Description

This PR fixes an incorrect hyperlink to `docs/contribution.md` in `docs/README.md`.

## Related Issue

Closes #10

## Proposed Changes

- Fixes hyperlink in `docs/README.md`.