### PR TITLE
Add NVIDIA licensing notices (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ This framework enables:
 
 The source code in this repository is licensed under the [MIT License](LICENSE). 
 
-This project utilizes model configurations and pre-trained weights derived from [NV-Generate-CT](https://huggingface.co/nvidia/NV-Generate-CT). To run some code, you must download these assets directly from the original source and place them in your local directory.
+This project utilizes model configurations and pre-trained weights derived from [NV-Generate-CT](https://huggingface.co/nvidia/NV-Generate-CT). To run some parts of the code, you must download these assets directly from the original source and place them in your local directory.
 
 Please note that these external assets are licensed by NVIDIA Corporation under the **NVIDIA Open Model License**.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ This framework enables:
 3. **Uncertainty quantification**: Quantify dose uncertainty due to anatomical variations.
 4. **Quality assurance**: Validate delivered dose against predicted variations.
 5. **Research**: Study inter-fraction anatomical changes and their dosimetric impact.
+
+## Acknowledgments & Licensing
+
+The source code in this repository is licensed under the [MIT License](LICENSE). 
+
+This project utilizes model configurations and pre-trained weights derived from [NV-Generate-CT](https://huggingface.co/nvidia/NV-Generate-CT). To run some code, you must download these assets directly from the original source and place them in your local directory.
+
+Please note that these external assets are licensed by NVIDIA Corporation under the **NVIDIA Open Model License**.

--- a/notebooks/maisi_ct_generation.ipynb
+++ b/notebooks/maisi_ct_generation.ipynb
@@ -5,6 +5,8 @@
    "id": "6fd353f6-285e-439d-828c-d5c90d475759",
    "metadata": {},
    "source": [
+    "**NOTICE**: This file utilizes configurations and pre-trained weights derived from [NV-Generate-CT](https://huggingface.co/nvidia/NV-Generate-CT). Licensed by NVIDIA Corporation under the NVIDIA Open Model License.\n",
+    "\n",
     "# MAISI CT generation through foundation model\n",
     "\n",
     "The purpose of this notebook is to load the VAE and Rectified Flow foundation models published [here](https://huggingface.co/nvidia/NV-Generate-CT/blob/main/configs/config_network_rflow.json) and use them to generate an example CT for each patient. The model provided is not conditioned on a planning CT so the weights corresponding to the conditioning in U-Net are initialized as 0."

--- a/src/pipeline/config.py
+++ b/src/pipeline/config.py
@@ -1,3 +1,6 @@
+# NOTICE: This file utilizes configurations derived from: https://huggingface.co/nvidia/NV-Generate-CT
+# Licensed by NVIDIA Corporation under the NVIDIA Open Model License.
+
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal


### PR DESCRIPTION
## Description

This PR adds licensing notices relating to the configs and weights derived from [NV-Generate-CT](https://huggingface.co/nvidia/NV-Generate-CT). This is needed according to the [NVIDIA Open Model License Agreement](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license/).

## Related Issue

Closes #30 

## Proposed Changes

- Adds the NVIDIA notice to `README.md`.
- Adds the NVIDIA notice to `config.py`.
- Adds the NVIDIA notice to `maisi_ct_generation.ipynb`.