### PR TITLE
Update evaluation/testing pipeline configuration and alignment with training setting (#37)

### DIFF
--- a/src/pipeline/cli.py
+++ b/src/pipeline/cli.py
@@ -31,6 +31,8 @@ def parse_args() -> argparse.Namespace:
         - device
         - cts_per_patient
         - steps
+        - evaluation_split
+        - validation_fold
         - no_validate_paths
         - no_lpips
         - generated_ct_dir
@@ -58,6 +60,20 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=30,
         help="Number of rectified flow sampling steps",
+    )
+
+    parser.add_argument(
+        "--evaluation-split",
+        choices=["test", "val"],
+        default="test",
+        help="Dataset split to run the pipeline on",
+    )
+
+    parser.add_argument(
+        "--validation-fold",
+        type=int,
+        default=0,
+        help="Cross-validation fold to use when --evaluation-split=val",
     )
 
     parser.add_argument(
@@ -124,6 +140,8 @@ def build_config(args: argparse.Namespace) -> MaisiTestingConfig:
         "validate_paths": not args.no_validate_paths,
         "cts_per_patient": args.cts_per_patient,
         "steps": args.steps,
+        "evaluation_split": args.evaluation_split,
+        "validation_fold": args.validation_fold,
         "use_lpips": not args.no_lpips,
     }
 

--- a/src/pipeline/config.py
+++ b/src/pipeline/config.py
@@ -168,11 +168,13 @@ class MaisiTestingConfig:
 
     # Output paths
     output_root: Path = Path("RESULTS/MAISI_TESTING")
+    evaluation_split: Literal["test", "val"] = "test"
+    validation_fold: int = 0
 
     processed_ct_dir: Path = output_root / "processed_ct" / "test"
     latent_ct_dir: Path = output_root / "latents" / "test"
     generated_ct_dir: Path = output_root / "generated_ct" / "test"
-    metrics_dir: Path = output_root / "metrics"
+    metrics_dir: Path = output_root / "metrics" / "test"
     logs_dir: Path = output_root / "logs"
 
     # Model weights
@@ -184,7 +186,7 @@ class MaisiTestingConfig:
     # Inference config
     cts_per_patient: int = 1
     steps: int = 30
-    latent_scale: float = 1.0
+    latent_scale: float = 1.949401
     device: str = field(default_factory=lambda: "cuda" if torch.cuda.is_available() else "cpu")
 
     # MAISI-specific config
@@ -250,11 +252,37 @@ class MaisiTestingConfig:
         self._set_default_vae_config()
         self._set_default_rflow_config()
         self._set_default_scheduler_config()
+        self._set_split_output_dirs()
 
         self._create_output_dirs()
         if self.validate_paths:
             self._validate_paths()
         self._validate_inference_settings()
+
+    def _set_split_output_dirs(self) -> None:
+        """
+        Point default output directories at the configured evaluation split.
+        """
+
+        if self.evaluation_split == "test":
+            return
+
+        default_processed_ct_dir = self.output_root / "processed_ct" / "test"
+        default_latent_ct_dir = self.output_root / "latents" / "test"
+        default_generated_ct_dir = self.output_root / "generated_ct" / "test"
+        default_metrics_dir = self.output_root / "metrics" / "test"
+
+        if self.processed_ct_dir == default_processed_ct_dir:
+            self.processed_ct_dir = self.output_root / "processed_ct" / self.evaluation_split
+
+        if self.latent_ct_dir == default_latent_ct_dir:
+            self.latent_ct_dir = self.output_root / "latents" / self.evaluation_split
+
+        if self.generated_ct_dir == default_generated_ct_dir:
+            self.generated_ct_dir = self.output_root / "generated_ct" / self.evaluation_split
+
+        if self.metrics_dir == default_metrics_dir:
+            self.metrics_dir = self.output_root / "metrics" / self.evaluation_split
 
     def _create_output_dirs(self) -> None:
         """
@@ -312,6 +340,12 @@ class MaisiTestingConfig:
 
         if self.steps < 1:
             raise ValueError("`steps` must be at least 1")
+
+        if self.evaluation_split not in {"test", "val"}:
+            raise ValueError(f"`evaluation_split` must be either 'test' or 'val'. Got {self.evaluation_split}")
+
+        if self.validation_fold < 0:
+            raise ValueError("`validation_fold` must be non-negative")
 
         if self.latent_scale <= 0:
             raise ValueError("`latent_scale` must be greater than 0")
@@ -448,5 +482,5 @@ class MaisiTestingConfig:
                 "use_discrete_timesteps": False,
                 "use_timestep_transform": True,
                 "sample_method": "uniform",
-                "base_img_size_numel": 64 * 64 * 16,
+                "base_img_size_numel": 128 * 128 * 32,
             }

--- a/src/pipeline/data/prepare_test_data.py
+++ b/src/pipeline/data/prepare_test_data.py
@@ -192,12 +192,12 @@ def prepare_test_data(
     folds: int = 5,
 ) -> None:
     """
-    Prepare MAISI testing data from the test split.
+    Prepare MAISI evaluation data from the configured split.
 
     This function:
     - creates or loads the longitudinal CT train/validation/test split
-    - selects the test split
-    - extracts planning CTs from the test set
+    - selects the configured test or validation split
+    - extracts planning CTs from the selected split
     - preprocesses planning CTs
     - saves processed CT tensors to config.processed_ct_dir
 
@@ -232,10 +232,10 @@ def prepare_test_data(
     Raises
     ------
     KeyError
-        If the generated data dictionary does not contain the "test" key.
+        If the generated data dictionary does not contain the requested split.
 
     ValueError
-        If the test split is empty or invalid.
+        If the requested split is empty or invalid.
 
     FileNotFoundError
         If required CT files do not exist.
@@ -250,14 +250,30 @@ def prepare_test_data(
         save=False,
     )
 
-    if "test" not in data_dict:
-        raise KeyError("The data dictionary does not contain a 'test' split")
+    if config.evaluation_split == "test":
+        if "test" not in data_dict:
+            raise KeyError("The data dictionary does not contain a 'test' split")
 
-    if len(data_dict["test"]) == 0:
-        raise ValueError("The test split is empty. Cannot prepare MAISI test data")
+        data_path_list = data_dict["test"]
+
+    else:
+        if config.validation_fold not in data_dict:
+            raise KeyError(f"The data dictionary does not contain validation fold {config.validation_fold}")
+
+        fold_dict = data_dict[config.validation_fold]
+
+        if "val" not in fold_dict:
+            raise KeyError(f"Validation fold {config.validation_fold} does not contain a 'val' split")
+
+        data_path_list = fold_dict["val"]
+
+    if len(data_path_list) == 0:
+        raise ValueError(
+            f"The {config.evaluation_split} split is empty. Cannot prepare MAISI {config.evaluation_split} data"
+        )
 
     process_and_save_planning_cts(
         config=config,
         output_dir=config.processed_ct_dir,
-        data_path_list=data_dict["test"],
+        data_path_list=data_path_list,
     )

--- a/src/pipeline/inference/run_generation.py
+++ b/src/pipeline/inference/run_generation.py
@@ -285,7 +285,7 @@ def generate_ct_variants(config: MaisiTestingConfig) -> None:
         pin_memory=device.type == "cuda",
     )
 
-    class_labels = torch.tensor([0], dtype=torch.long, device=device)
+    class_labels = torch.tensor([2], dtype=torch.long, device=device)
     spacing_tensor = torch.tensor(
         [[*config.spacing]],
         dtype=torch.float32,
@@ -300,7 +300,7 @@ def generate_ct_variants(config: MaisiTestingConfig) -> None:
             loader,
             desc="Generating CT variants",
         ):
-            condition_latent = condition_latent.to(device, non_blocking=True)
+            condition_latent = condition_latent.to(device, non_blocking=True) * config.latent_scale
 
             filename = os.path.basename(condition_path[0])
 
@@ -336,7 +336,7 @@ def generate_ct_variants(config: MaisiTestingConfig) -> None:
                     )
 
                 reconstructed_ct = decode_latent_to_ct(
-                    z_t=z_t,
+                    z_t=z_t / config.latent_scale,
                     vae_model=vae_model,
                     config=config,
                 )


### PR DESCRIPTION
## Description

This PR updates the evaluation and testing pipeline configuration to align with the current training setup and expected evaluation workflow. It standardizes configuration values, ensures consistency between training and evaluation, and adds flexibility for running evaluations on different datasets.

## Related issue

Closes #37 

## Proposed Changes

* Updates the evaluation/testing pipeline configuration from **64×64×16** to **128×128×32**.
* Verifies that all evaluation and testing jobs reference the updated configuration.
* Sets the latent scale to match the value used during training.
* Adds support for running the evaluation pipeline on the **validation set** in addition to the test set.
* Updates the evaluation pipeline to use **class label 2** for the U-Net instead of **0**.
