### PR TITLE
Fix non-planning CTs bug (#40)

### DIFF
--- a/notebooks/pipeline_testing.ipynb
+++ b/notebooks/pipeline_testing.ipynb
@@ -75,7 +75,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Preparing planning CTs: 100%|██████████████████████████████████████████████████████████| 15/15 [00:11<00:00,  1.33it/s]\n"
+      "Preparing CTs: 100%|█████████████████████████████████████████████████████████████████| 444/444 [09:18<00:00,  1.26s/it]\n"
      ]
     }
    ],
@@ -93,7 +93,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Encoding planning CTs: 100%|███████████████████████████████████████████████████████████| 15/15 [01:05<00:00,  4.38s/it]\n"
+      "Encoding planning CTs: 100%|███████████████████████████████████████████████████████████| 15/15 [01:07<00:00,  4.50s/it]\n"
      ]
     }
    ],
@@ -111,7 +111,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Generating CT variants: 100%|███████████████████████████████████████████████████████| 15/15 [1:36:47<00:00, 387.19s/it]\n"
+      "Generating CT variants: 100%|███████████████████████████████████████████████████████| 15/15 [1:54:46<00:00, 459.12s/it]\n"
      ]
     }
    ],
@@ -121,10 +121,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "2f2a2496-c65a-4c2c-9906-2eda47a95262",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Setting up [LPIPS] perceptual loss: trunk [alex], v[0.1], spatial [off]\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -139,7 +146,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Setting up [LPIPS] perceptual loss: trunk [alex], v[0.1], spatial [off]\n",
       "Loading model from: C:\\Users\\Wiktoria\\Documents\\GitHub\\robust-radiotherapy-planning\\.venv\\Lib\\site-packages\\lpips\\weights\\v0.1\\alex.pth\n"
      ]
     },
@@ -147,7 +153,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Generated vs real metrics: 100%|███████████████████████████████████████████████████████| 15/15 [02:30<00:00, 10.00s/it]\n",
+      "Generated vs real metrics: 100%|████████████████████████████████████████████████████| 15/15 [1:52:26<00:00, 449.79s/it]\n",
       "C:\\Users\\Wiktoria\\Documents\\GitHub\\robust-radiotherapy-planning\\.venv\\Lib\\site-packages\\torchvision\\models\\_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.\n",
       "  warnings.warn(\n",
       "C:\\Users\\Wiktoria\\Documents\\GitHub\\robust-radiotherapy-planning\\.venv\\Lib\\site-packages\\torchvision\\models\\_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=AlexNet_Weights.IMAGENET1K_V1`. You can also use `weights=AlexNet_Weights.DEFAULT` to get the most up-to-date weights.\n",
@@ -204,22 +210,24 @@
      "traceback": [
       "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
       "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[7]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mevaluate_generated_cts\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m      2\u001b[39m \u001b[43m    \u001b[49m\u001b[43mgenerated_ct_dir\u001b[49m\u001b[43m=\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m.\u001b[49m\u001b[43mgenerated_ct_dir\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m      3\u001b[39m \u001b[43m    \u001b[49m\u001b[43moriginal_ct_dir\u001b[49m\u001b[43m=\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m.\u001b[49m\u001b[43mprocessed_ct_dir\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m      4\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmetrics_dir\u001b[49m\u001b[43m=\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmetrics_dir\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m      5\u001b[39m \u001b[43m    \u001b[49m\u001b[43muse_lpips\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m      6\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m=\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m.\u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m      7\u001b[39m \u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\Documents\\GitHub\\robust-radiotherapy-planning\\src\\pipeline\\evaluation\\metrics.py:1084\u001b[39m, in \u001b[36mevaluate_generated_cts\u001b[39m\u001b[34m(generated_ct_dir, original_ct_dir, metrics_dir, use_lpips, device)\u001b[39m\n\u001b[32m   1074\u001b[39m originals = collect_original_cts(original_ct_dir)\n\u001b[32m   1076\u001b[39m calculate_similarity_metrics(\n\u001b[32m   1077\u001b[39m     generated_ct_dir=generated_ct_dir,\n\u001b[32m   1078\u001b[39m     original_ct_dir=original_ct_dir,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1081\u001b[39m     device=device,\n\u001b[32m   1082\u001b[39m )\n\u001b[32m-> \u001b[39m\u001b[32m1084\u001b[39m \u001b[43mcalculate_pairwise_variety_metrics\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1085\u001b[39m \u001b[43m    \u001b[49m\u001b[43mct_groups\u001b[49m\u001b[43m=\u001b[49m\u001b[43mgenerated\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1086\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmetrics_dir\u001b[49m\u001b[43m=\u001b[49m\u001b[43mmetrics_dir\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1087\u001b[39m \u001b[43m    \u001b[49m\u001b[43moutput_filename\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mgenerated_pairwise_variety_metrics.csv\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   1088\u001b[39m \u001b[43m    \u001b[49m\u001b[43mcomparison_type\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mgenerated_vs_generated\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   1089\u001b[39m \u001b[43m    \u001b[49m\u001b[43muse_lpips\u001b[49m\u001b[43m=\u001b[49m\u001b[43muse_lpips\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1090\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m=\u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1091\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1093\u001b[39m calculate_pairwise_variety_metrics(\n\u001b[32m   1094\u001b[39m     ct_groups=originals,\n\u001b[32m   1095\u001b[39m     metrics_dir=metrics_dir,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1099\u001b[39m     device=device,\n\u001b[32m   1100\u001b[39m )\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\Documents\\GitHub\\robust-radiotherapy-planning\\src\\pipeline\\evaluation\\metrics.py:1005\u001b[39m, in \u001b[36mcalculate_pairwise_variety_metrics\u001b[39m\u001b[34m(ct_groups, metrics_dir, output_filename, comparison_type, use_lpips, lpips_net, max_lpips_slices, device)\u001b[39m\n\u001b[32m   1002\u001b[39m         rows.append(row)\n\u001b[32m   1004\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(rows) == \u001b[32m0\u001b[39m:\n\u001b[32m-> \u001b[39m\u001b[32m1005\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo valid pairwise comparisons were calculated for `\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcomparison_type\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m`.\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m   1007\u001b[39m df = pd.DataFrame(rows)\n\u001b[32m   1009\u001b[39m df.to_csv(\n\u001b[32m   1010\u001b[39m     metrics_dir / output_filename,\n\u001b[32m   1011\u001b[39m     index=\u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[32m   1012\u001b[39m )\n",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[8]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mevaluate_generated_cts\u001b[49m\u001b[43m(\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\Documents\\GitHub\\robust-radiotherapy-planning\\src\\pipeline\\evaluation\\metrics.py:1044\u001b[39m, in \u001b[36mevaluate_generated_cts\u001b[39m\u001b[34m(config)\u001b[39m\n\u001b[32m   1038\u001b[39m originals = collect_original_cts(config.processed_ct_dir)\n\u001b[32m   1040\u001b[39m calculate_similarity_metrics(\n\u001b[32m   1041\u001b[39m     config=config,\n\u001b[32m   1042\u001b[39m )\n\u001b[32m-> \u001b[39m\u001b[32m1044\u001b[39m \u001b[43mcalculate_pairwise_variety_metrics\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1045\u001b[39m \u001b[43m    \u001b[49m\u001b[43mct_groups\u001b[49m\u001b[43m=\u001b[49m\u001b[43mgenerated\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1046\u001b[39m \u001b[43m    \u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m=\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1047\u001b[39m \u001b[43m    \u001b[49m\u001b[43moutput_filename\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mgenerated_pairwise_variety_metrics.csv\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   1048\u001b[39m \u001b[43m    \u001b[49m\u001b[43mcomparison_type\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mgenerated_vs_generated\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   1049\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1051\u001b[39m calculate_pairwise_variety_metrics(\n\u001b[32m   1052\u001b[39m     ct_groups=originals,\n\u001b[32m   1053\u001b[39m     config=config,\n\u001b[32m   1054\u001b[39m     output_filename=\u001b[33m\"\u001b[39m\u001b[33mreal_pairwise_variety_metrics.csv\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   1055\u001b[39m     comparison_type=\u001b[33m\"\u001b[39m\u001b[33mreal_vs_real\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   1056\u001b[39m )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~\\Documents\\GitHub\\robust-radiotherapy-planning\\src\\pipeline\\evaluation\\metrics.py:984\u001b[39m, in \u001b[36mcalculate_pairwise_variety_metrics\u001b[39m\u001b[34m(ct_groups, config, output_filename, comparison_type)\u001b[39m\n\u001b[32m    981\u001b[39m         rows.append(row)\n\u001b[32m    983\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(rows) == \u001b[32m0\u001b[39m:\n\u001b[32m--> \u001b[39m\u001b[32m984\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo valid pairwise comparisons were calculated for `\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcomparison_type\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m`.\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m    986\u001b[39m df = pd.DataFrame(rows)\n\u001b[32m    988\u001b[39m df.to_csv(\n\u001b[32m    989\u001b[39m     config.metrics_dir / output_filename,\n\u001b[32m    990\u001b[39m     index=\u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[32m    991\u001b[39m )\n",
       "\u001b[31mValueError\u001b[39m: No valid pairwise comparisons were calculated for `generated_vs_generated`."
      ]
     }
    ],
    "source": [
-    "evaluate_generated_cts(\n",
-    "    generated_ct_dir=config.generated_ct_dir,\n",
-    "    original_ct_dir=config.processed_ct_dir,\n",
-    "    metrics_dir=config.metrics_dir,\n",
-    "    use_lpips=True,\n",
-    "    device=config.device,\n",
-    ")"
+    "evaluate_generated_cts(config)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edb1e851-61fa-4f4b-a16d-9adcc6b2ce15",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,10 @@ exclude = [
 # Standard stability settings
 warn_unused_configs = true
 
+[[tool.mypy.overrides]]
+module = "wandb"
+ignore_missing_imports = true
+
 [dependency-groups]
 dev = [
     "pandas-stubs>=3.0.3.260530,<4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,6 @@ exclude = [
 # Standard stability settings
 warn_unused_configs = true
 
-[[tool.mypy.overrides]]
-module = "wandb"
-ignore_missing_imports = true
-
 [dependency-groups]
 dev = [
     "pandas-stubs>=3.0.3.260530,<4.0.0",

--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -15,12 +15,12 @@ class LoadProcessedTensord(MapTransform):
     """
     Load processed CT tensors saved as `.pt` files.
 
-    This transform is used after the preprocessing step, where planning CTs
+    This transform is used after the preprocessing step, where CTs
     are already loaded, scaled, cropped/padded, and saved as torch tensors.
 
     Assumptions:
     - Input files are `.pt` tensors.
-    - Each file contains one processed planning CT.
+    - Each file contains one processed CT.
     - The tensor was created by `prepare_test_data.py`.
     - The dictionary contains keys listed in `self.keys`.
 

--- a/src/pipeline/cli.py
+++ b/src/pipeline/cli.py
@@ -17,8 +17,8 @@ def parse_args() -> argparse.Namespace:
     pipeline.
 
     Available stages:
-    - prepare: preprocess test planning CTs
-    - encode: encode processed CTs into latent space
+    - prepare: preprocess test CTs
+    - encode: encode processed planning CTs into latent space
     - generate: generate CT variants from latent conditions
     - evaluate: calculate evaluation metrics
     - all: run all stages in order
@@ -167,8 +167,8 @@ def run_stage(
     Run one selected MAISI testing pipeline stage.
 
     Supported stages:
-    - prepare: preprocess test planning CTs
-    - encode: encode processed CTs into latent space
+    - prepare: preprocess test CTs
+    - encode: encode processed planning CTs into latent space
     - generate: generate CT variants from latent conditions
     - evaluate: calculate generated-vs-real and variety metrics
     - all: run prepare, encode, generate, and evaluate in sequence

--- a/src/pipeline/data/prepare_test_data.py
+++ b/src/pipeline/data/prepare_test_data.py
@@ -1,5 +1,6 @@
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import torch
 from monai.transforms import (  # type: ignore[attr-defined]
@@ -65,25 +66,32 @@ def get_ct_preprocessing_transform(config: MaisiTestingConfig) -> Compose:
     )
 
 
-def _extract_planning_ct_paths(data_path_list: list[str | dict[str, Any]]) -> list[str]:
+def _is_planning_ct_path(path: str) -> bool:
     """
-    Extract planning CT paths from a test data list.
+    Check whether a CT path points to the planning CT.
+    """
+
+    return "fraction_1_" in Path(path).name
+
+
+def _extract_all_ct_paths(data_path_list: Sequence[str | dict[str, Any]]) -> list[str]:
+    """
+    Extract all unique CT paths from a test data list.
 
     Assumptions:
-    - Planning CT is fraction 1.
     - The data list may contain either raw path strings or dictionaries.
-    - If dictionaries are used, the planning CT path is expected under
-      the key "moving_image".
+    - If dictionaries are used, CT paths are read from "moving_image" and
+      "fixed_image" when present.
 
     Parameters
     ----------
-    data_path_list : list[str | dict[str, Any]]
+    data_path_list : Sequence[str | dict[str, Any]]
         List of CT paths or dictionaries describing CT pairs.
 
     Returns
     -------
-    planning_ct_paths : list[str]
-        List of paths pointing to planning CT images.
+    ct_paths : list[str]
+        List of unique paths pointing to CT images.
 
     Raises
     ------
@@ -91,52 +99,62 @@ def _extract_planning_ct_paths(data_path_list: list[str | dict[str, Any]]) -> li
         If an item in the data list has an unsupported format.
     """
 
-    planning_ct_paths = []
+    ct_paths: list[str] = []
+    seen_paths: set[str] = set()
 
     for item in data_path_list:
         if isinstance(item, str):
-            path = item
+            item_paths = [item]
 
         elif isinstance(item, dict):
-            if "moving_image" not in item:
+            item_paths = [cast(str, item[key]) for key in ("moving_image", "fixed_image") if key in item]
+            if len(item_paths) == 0:
                 raise ValueError(
-                    f"Expected dictionary item to contain key 'moving_image'. Got keys: {list(item.keys())}"
+                    "Expected dictionary item to contain at least one of 'moving_image' or 'fixed_image'. "
+                    f"Got keys: {list(item.keys())}"
                 )
-
-            path = item["moving_image"]
 
         else:
             raise ValueError(f"Each test item must be either a string path or a dictionary. Got: {type(item)}")
 
-        if "fraction_1_" in path:
-            planning_ct_paths.append(path)
+        for path in item_paths:
+            if path not in seen_paths:
+                ct_paths.append(path)
+                seen_paths.add(path)
 
-    return planning_ct_paths
+    return ct_paths
 
 
-def process_and_save_planning_cts(
+def _extract_planning_ct_paths(data_path_list: Sequence[str | dict[str, Any]]) -> list[str]:
+    """
+    Extract unique planning CT paths from a test data list.
+    """
+
+    return [path for path in _extract_all_ct_paths(data_path_list) if _is_planning_ct_path(path)]
+
+
+def process_and_save_cts(
     config: MaisiTestingConfig,
-    data_path_list: list[str | dict[str, Any]],
+    data_path_list: Sequence[str | dict[str, Any]],
     output_dir: Path | None = None,
 ) -> None:
     """
-    Preprocess planning CTs and save them as `.pt` tensors.
+    Preprocess all CTs and save them as `.pt` tensors.
 
     Assumptions:
-    - Planning CTs are identified by "fraction_1_" in the filename.
-    - Only planning CTs are currently used as the condition image.
     - Output tensors are saved as `.pt` files.
-    - Saved tensors are later used by the MAISI VAE encoder.
+    - Saved planning CT tensors are later used by the MAISI VAE encoder.
+    - Saved non-planning CT tensors are used as real CTs during evaluation.
 
     Parameters
     ----------
     config : MaisiTestingConfig
         Configuration object containing pipeline paths and settings.
 
-    data_path_list : list[str | dict[str, Any]]
+    data_path_list : Sequence[str | dict[str, Any]]
         List of CT paths or dictionary items from the test split.
         Supported formats:
-            "path/to/Patient_1_fraction_1_.nii.gz"
+            "path/to/Patient_1_fraction_2_.nii.gz"
 
         or:
             {
@@ -152,10 +170,10 @@ def process_and_save_planning_cts(
     Raises
     ------
     FileNotFoundError
-        If one of the planning CT files does not exist.
+        If one of the CT files does not exist.
 
     ValueError
-        If no planning CTs are found in the provided data list.
+        If no CTs are found in the provided data list.
     """
 
     if output_dir is None:
@@ -164,16 +182,16 @@ def process_and_save_planning_cts(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     transform = get_ct_preprocessing_transform(config)
-    planning_ct_paths = _extract_planning_ct_paths(data_path_list)
+    ct_paths = _extract_all_ct_paths(data_path_list)
 
-    if len(planning_ct_paths) == 0:
-        raise ValueError("No planning CTs were found. Expected filenames containing 'fraction_1_'.")
+    if len(ct_paths) == 0:
+        raise ValueError("No CTs were found in the provided data list.")
 
-    for path_raw in tqdm(planning_ct_paths, desc="Preparing planning CTs"):
+    for path_raw in tqdm(ct_paths, desc="Preparing CTs"):
         path = Path(path_raw)
 
         if not path.exists():
-            raise FileNotFoundError(f"Planning CT file does not exist: {path}")
+            raise FileNotFoundError(f"CT file does not exist: {path}")
 
         transformed = transform({"image": str(path)})
         tensor_data = transformed["image"]
@@ -183,6 +201,31 @@ def process_and_save_planning_cts(
 
         clean_tensor = tensor_data.as_tensor().clone().detach()
         torch.save(clean_tensor, save_path)
+
+
+def process_and_save_planning_cts(
+    config: MaisiTestingConfig,
+    data_path_list: Sequence[str | dict[str, Any]],
+    output_dir: Path | None = None,
+) -> None:
+    """
+    Preprocess planning CTs and save them as `.pt` tensors.
+
+    This compatibility wrapper preserves the previous public helper behavior.
+    The full pipeline uses :func:`process_and_save_cts` so evaluation has all
+    real CT fractions available.
+    """
+
+    planning_ct_paths = _extract_planning_ct_paths(data_path_list)
+
+    if len(planning_ct_paths) == 0:
+        raise ValueError("No planning CTs were found. Expected filenames containing 'fraction_1_'.")
+
+    process_and_save_cts(
+        config=config,
+        data_path_list=planning_ct_paths,
+        output_dir=output_dir,
+    )
 
 
 def prepare_test_data(
@@ -197,8 +240,8 @@ def prepare_test_data(
     This function:
     - creates or loads the longitudinal CT train/validation/test split
     - selects the configured test or validation split
-    - extracts planning CTs from the selected split
-    - preprocesses planning CTs
+    - extracts all CTs from the selected split
+    - preprocesses all CTs
     - saves processed CT tensors to config.processed_ct_dir
 
     Assumptions:
@@ -210,6 +253,8 @@ def prepare_test_data(
         ...
     - Fraction 1 is the planning CT.
     - Planning CT is used as the condition image for MAISI generation.
+    - All CT fractions are saved so evaluation can compare generated CTs
+      against real non-planning CTs.
     - The output directory is:
         config.processed_ct_dir
 
@@ -272,7 +317,7 @@ def prepare_test_data(
             f"The {config.evaluation_split} split is empty. Cannot prepare MAISI {config.evaluation_split} data"
         )
 
-    process_and_save_planning_cts(
+    process_and_save_cts(
         config=config,
         output_dir=config.processed_ct_dir,
         data_path_list=data_path_list,

--- a/src/pipeline/data/prepare_test_data.py
+++ b/src/pipeline/data/prepare_test_data.py
@@ -1,6 +1,5 @@
-from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import torch
 from monai.transforms import (  # type: ignore[attr-defined]
@@ -17,6 +16,7 @@ from tqdm import tqdm
 
 from src.data_utils import create_data_split_dict
 from src.pipeline.config import MaisiTestingConfig
+from src.pipeline.helpers.helpers import _extract_all_ct_paths, _is_planning_ct_path
 
 
 def get_ct_preprocessing_transform(config: MaisiTestingConfig) -> Compose:
@@ -66,76 +66,9 @@ def get_ct_preprocessing_transform(config: MaisiTestingConfig) -> Compose:
     )
 
 
-def _is_planning_ct_path(path: str) -> bool:
-    """
-    Check whether a CT path points to the planning CT.
-    """
-
-    return "fraction_1_" in Path(path).name
-
-
-def _extract_all_ct_paths(data_path_list: Sequence[str | dict[str, Any]]) -> list[str]:
-    """
-    Extract all unique CT paths from a test data list.
-
-    Assumptions:
-    - The data list may contain either raw path strings or dictionaries.
-    - If dictionaries are used, CT paths are read from "moving_image" and
-      "fixed_image" when present.
-
-    Parameters
-    ----------
-    data_path_list : Sequence[str | dict[str, Any]]
-        List of CT paths or dictionaries describing CT pairs.
-
-    Returns
-    -------
-    ct_paths : list[str]
-        List of unique paths pointing to CT images.
-
-    Raises
-    ------
-    ValueError
-        If an item in the data list has an unsupported format.
-    """
-
-    ct_paths: list[str] = []
-    seen_paths: set[str] = set()
-
-    for item in data_path_list:
-        if isinstance(item, str):
-            item_paths = [item]
-
-        elif isinstance(item, dict):
-            item_paths = [cast(str, item[key]) for key in ("moving_image", "fixed_image") if key in item]
-            if len(item_paths) == 0:
-                raise ValueError(
-                    "Expected dictionary item to contain at least one of 'moving_image' or 'fixed_image'. "
-                    f"Got keys: {list(item.keys())}"
-                )
-
-        else:
-            raise ValueError(f"Each test item must be either a string path or a dictionary. Got: {type(item)}")
-
-        for path in item_paths:
-            if path not in seen_paths:
-                ct_paths.append(path)
-                seen_paths.add(path)
-
-    return ct_paths
-
-
-def _extract_planning_ct_paths(data_path_list: Sequence[str | dict[str, Any]]) -> list[str]:
-    """
-    Extract unique planning CT paths from a test data list.
-    """
-
-    return [path for path in _extract_all_ct_paths(data_path_list) if _is_planning_ct_path(path)]
-
-
 def process_and_save_cts(
     config: MaisiTestingConfig,
-    data_path_list: Sequence[str | dict[str, Any]],
+    data_path_list: list[str] | list[dict[str, Any]],
     output_dir: Path | None = None,
 ) -> None:
     """
@@ -151,7 +84,7 @@ def process_and_save_cts(
     config : MaisiTestingConfig
         Configuration object containing pipeline paths and settings.
 
-    data_path_list : Sequence[str | dict[str, Any]]
+    data_path_list : list[str] | list[dict[str, Any]]
         List of CT paths or dictionary items from the test split.
         Supported formats:
             "path/to/Patient_1_fraction_2_.nii.gz"
@@ -185,7 +118,7 @@ def process_and_save_cts(
     ct_paths = _extract_all_ct_paths(data_path_list)
 
     if len(ct_paths) == 0:
-        raise ValueError("No CTs were found in the provided data list.")
+        raise ValueError("No CTs were found in the provided data list")
 
     for path_raw in tqdm(ct_paths, desc="Preparing CTs"):
         path = Path(path_raw)
@@ -205,7 +138,7 @@ def process_and_save_cts(
 
 def process_and_save_planning_cts(
     config: MaisiTestingConfig,
-    data_path_list: Sequence[str | dict[str, Any]],
+    data_path_list: list[str] | list[dict[str, Any]],
     output_dir: Path | None = None,
 ) -> None:
     """
@@ -216,7 +149,7 @@ def process_and_save_planning_cts(
     real CT fractions available.
     """
 
-    planning_ct_paths = _extract_planning_ct_paths(data_path_list)
+    planning_ct_paths = [path for path in _extract_all_ct_paths(data_path_list) if _is_planning_ct_path(path)]
 
     if len(planning_ct_paths) == 0:
         raise ValueError("No planning CTs were found. Expected filenames containing 'fraction_1_'.")

--- a/src/pipeline/data/prepare_test_data.py
+++ b/src/pipeline/data/prepare_test_data.py
@@ -16,7 +16,7 @@ from tqdm import tqdm
 
 from src.data_utils import create_data_split_dict
 from src.pipeline.config import MaisiTestingConfig
-from src.pipeline.helpers.helpers import _extract_all_ct_paths, _is_planning_ct_path
+from src.pipeline.helpers.helpers import _extract_all_ct_paths
 
 
 def get_ct_preprocessing_transform(config: MaisiTestingConfig) -> Compose:
@@ -134,31 +134,6 @@ def process_and_save_cts(
 
         clean_tensor = tensor_data.as_tensor().clone().detach()
         torch.save(clean_tensor, save_path)
-
-
-def process_and_save_planning_cts(
-    config: MaisiTestingConfig,
-    data_path_list: list[str] | list[dict[str, Any]],
-    output_dir: Path | None = None,
-) -> None:
-    """
-    Preprocess planning CTs and save them as `.pt` tensors.
-
-    This compatibility wrapper preserves the previous public helper behavior.
-    The full pipeline uses :func:`process_and_save_cts` so evaluation has all
-    real CT fractions available.
-    """
-
-    planning_ct_paths = [path for path in _extract_all_ct_paths(data_path_list) if _is_planning_ct_path(path)]
-
-    if len(planning_ct_paths) == 0:
-        raise ValueError("No planning CTs were found. Expected filenames containing 'fraction_1_'.")
-
-    process_and_save_cts(
-        config=config,
-        data_path_list=planning_ct_paths,
-        output_dir=output_dir,
-    )
 
 
 def prepare_test_data(

--- a/src/pipeline/evaluation/metrics.py
+++ b/src/pipeline/evaluation/metrics.py
@@ -191,6 +191,25 @@ def _extract_patient_id(path: str | Path) -> str:
     return patient_id
 
 
+def _is_planning_ct_path(path: str | Path) -> bool:
+    """
+    Check whether a CT tensor path points to the planning CT.
+    """
+
+    return "fraction_1_" in Path(path).name
+
+
+def _exclude_planning_cts(ct_groups: dict[str, list[Path]]) -> dict[str, list[Path]]:
+    """
+    Remove planning CT paths from grouped CT tensors.
+    """
+
+    return {
+        patient_id: [path for path in paths if not _is_planning_ct_path(path)]
+        for patient_id, paths in ct_groups.items()
+    }
+
+
 def mae_3d(pred: np.ndarray, ref: np.ndarray) -> float:
     """
     Calculate mean absolute error between two 3D images.
@@ -758,9 +777,9 @@ def calculate_similarity_metrics(
     """
     Calculate generated-vs-real CT similarity metrics.
 
-    This function compares generated CT variants with available original or
-    reference CT tensors for the same patient. It is robust to missing generated
-    variants and calculates only comparisons that are possible.
+    This function compares generated CT variants with available non-planning
+    original/reference CT tensors for the same patient. It is robust to missing
+    generated variants and calculates only comparisons that are possible.
 
     Metrics:
     - MAE: lower is better
@@ -802,10 +821,15 @@ def calculate_similarity_metrics(
         generated.items(),
         desc="Generated vs real metrics",
     ):
-        ref_paths = originals.get(patient_id, [])
+        all_ref_paths = originals.get(patient_id, [])
+        ref_paths = _exclude_planning_cts({patient_id: all_ref_paths})[patient_id]
+
+        if len(all_ref_paths) == 0:
+            print(f"Skipping {patient_id}: no original/reference CT found")
+            continue
 
         if len(ref_paths) == 0:
-            print(f"Skipping {patient_id}: no original/reference CT found")
+            print(f"Skipping {patient_id}: no non-planning original/reference CT found")
             continue
 
         for gen_path in gen_paths:
@@ -1038,6 +1062,7 @@ def evaluate_generated_cts(
 
     generated = collect_generated_cts(config.generated_ct_dir)
     originals = collect_original_cts(config.processed_ct_dir)
+    originals_without_planning = _exclude_planning_cts(originals)
 
     calculate_similarity_metrics(
         config=config,
@@ -1051,7 +1076,7 @@ def evaluate_generated_cts(
     )
 
     calculate_pairwise_variety_metrics(
-        ct_groups=originals,
+        ct_groups=originals_without_planning,
         config=config,
         output_filename="real_pairwise_variety_metrics.csv",
         comparison_type="real_vs_real",

--- a/src/pipeline/evaluation/metrics.py
+++ b/src/pipeline/evaluation/metrics.py
@@ -1,10 +1,9 @@
 import glob
 import itertools
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Protocol, cast
 
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
 import torch
 from scipy.ndimage import sobel
@@ -12,202 +11,17 @@ from skimage.metrics import structural_similarity as ssim
 from tqdm import tqdm
 
 from src.pipeline.config import MaisiTestingConfig
-
-
-def _load_tensor(path: str | Path) -> torch.Tensor:
-    """
-    Load a tensor from a `.pt` file and normalize its shape.
-
-    This helper loads tensors saved by different stages of the MAISI testing
-    pipeline. It supports files that contain either a raw tensor or a
-    dictionary with an `"image"` key.
-
-    Shape handling:
-    - If the tensor has 5 dimensions, the first dimension is treated as a
-      batch dimension and removed.
-    - If the tensor has 4 dimensions, the first dimension is treated as a
-      channel dimension and removed.
-    - The returned tensor is always converted to float and moved to CPU.
-
-    Parameters
-    ----------
-    path : str | Path
-        Path to the `.pt` tensor file.
-
-    Returns
-    -------
-    tensor : torch.Tensor
-        Loaded tensor as a CPU float tensor, usually with shape:
-        `(D, H, W)` or equivalent spatial dimensions.
-
-    Raises
-    ------
-    ValueError
-        If the loaded object is a dictionary but does not contain an `"image"`
-        key.
-    """
-    tensor = torch.load(path, weights_only=True)
-
-    if isinstance(tensor, dict):
-        if "image" in tensor:
-            tensor = tensor["image"]
-        else:
-            raise ValueError(f"Unsupported tensor dictionary keys: {tensor.keys()}")
-
-    tensor = tensor.float()
-
-    # Remove batch dimension if present.
-    if tensor.ndim == 5:
-        tensor = tensor[0]
-
-    # Remove channel dimension if present.
-    if tensor.ndim == 4:
-        tensor = tensor[0]
-
-    return cast(torch.Tensor, tensor.cpu())
-
-
-FloatArray = npt.NDArray[np.floating[Any]]
+from src.pipeline.helpers.helpers import (
+    FloatArray,
+    _exclude_planning_cts,
+    _extract_patient_id,
+    _load_tensor,
+    _to_numpy_hu,
+)
 
 
 class LPIPSModel(Protocol):
     def __call__(self, pred: torch.Tensor, ref: torch.Tensor) -> torch.Tensor: ...
-
-
-def _to_numpy_hu(
-    tensor: torch.Tensor,
-    data_min: float,
-    data_max: float,
-) -> FloatArray:
-    """
-    Convert a CT tensor to a NumPy array of HU values rounded to the nearest integer.
-
-    This helper supports two expected intensity formats:
-    - tensors normalized to the range [0, 1]
-    - HU-like tensors in the range approximately [data_min, data_max]
-
-    If the tensor is already outside hu, it is returned rounded as a
-    float32 NumPy array. Otherwise, values are linearly rescaled from [0, 1] to [data_min, data_max].
-
-    Parameters
-    ----------
-    tensor : torch.Tensor
-        Input CT tensor.
-
-    data_min: float
-        Minimum value allowed for the data.
-
-    data_max: float
-        Maximum value allowed for the data.
-
-    Returns
-    -------
-    arr : np.ndarray
-        CT image as a float32 NumPy array normalized to [data_min, data_max].
-
-    Raises
-    ------
-    ValueError
-        If `tensor` is empty.
-        If `tensor` contains NaN or infinite values.
-        If `data_min` is more than `data_max`.
-    """
-
-    if tensor.numel() == 0:
-        raise ValueError("`tensor` cannot be empty")
-
-    if not torch.isfinite(tensor).all():
-        raise ValueError("`tensor` contains NaN or infinite values")
-
-    if data_min >= data_max:
-        raise ValueError(f"`data_min` must be smaller than `data_max`. Got data_min={data_min}, data_max={data_max}")
-
-    arr = tensor.detach().cpu().numpy().astype(np.float32)
-
-    # Case 1: HU-like range [data_min, data_max]
-    if arr.min() < 0.0 or arr.max() > 1.0:
-        return arr.round()
-
-    # Case 2: normalized to [0, 1]
-    arr = ((data_max - data_min) * arr + data_min).astype(np.float32).round()
-
-    return arr
-
-
-def _extract_patient_id(path: str | Path) -> str:
-    """
-    Extract patient ID from a CT tensor filename or generated output path.
-
-    Supported filename patterns:
-    - Planning CT / original CT:
-        Patient_1_fraction_1_.pt -> Patient_1
-    - Generated CT:
-        Patient_1_gen_1.pt -> Patient_1
-
-    If neither pattern is found, the parent folder name is returned as a
-    fallback. This supports folder-based generated outputs such as:
-        generated_ct/test/Patient_1/Patient_1_gen_1.pt
-
-    Parameters
-    ----------
-    path : str | Path
-        Path to a CT tensor file.
-
-    Returns
-    -------
-    patient_id : str
-        Extracted patient ID.
-
-    Raises
-    ------
-    ValueError
-        If `path` is empty.
-        If patient ID cannot be extracted from the filename or parent folder.
-    """
-
-    path = Path(path)
-
-    if str(path).strip() == "":
-        raise ValueError("`path` cannot be empty")
-
-    name = path.name
-
-    if "_fraction_" in name:
-        patient_id = name.split("_fraction_")[0]
-
-    elif "_gen_" in name:
-        patient_id = name.split("_gen_")[0]
-
-    else:
-        # fallback for folder-based generated outputs
-        patient_id = path.parent.name
-
-    if patient_id == "":
-        raise ValueError(f"Could not extract patient ID from path: {path}")
-
-    if patient_id in {".", ".."}:
-        raise ValueError(f"Invalid patient ID extracted from path: {path}")
-
-    return patient_id
-
-
-def _is_planning_ct_path(path: str | Path) -> bool:
-    """
-    Check whether a CT tensor path points to the planning CT.
-    """
-
-    return "fraction_1_" in Path(path).name
-
-
-def _exclude_planning_cts(ct_groups: dict[str, list[Path]]) -> dict[str, list[Path]]:
-    """
-    Remove planning CT paths from grouped CT tensors.
-    """
-
-    return {
-        patient_id: [path for path in paths if not _is_planning_ct_path(path)]
-        for patient_id, paths in ct_groups.items()
-    }
 
 
 def mae_3d(pred: np.ndarray, ref: np.ndarray) -> float:

--- a/src/pipeline/evaluation/metrics.py
+++ b/src/pipeline/evaluation/metrics.py
@@ -913,7 +913,8 @@ def calculate_pairwise_variety_metrics(
         If `ct_groups` is empty.
         If `output_filename` does not end with ".csv".
         If `max_lpips_slices` is less than 1.
-        If no valid pairwise comparisons can be calculated.
+        If the inputs are invalid. If no valid pairwise comparisons can be
+        calculated, the metric file is skipped.
     """
 
     if len(ct_groups) == 0:
@@ -981,7 +982,8 @@ def calculate_pairwise_variety_metrics(
             rows.append(row)
 
     if len(rows) == 0:
-        raise ValueError(f"No valid pairwise comparisons were calculated for `{comparison_type}`.")
+        print(f"Skipping {comparison_type}: no valid pairwise comparisons were calculated.")
+        return
 
     df = pd.DataFrame(rows)
 
@@ -1002,7 +1004,7 @@ def evaluate_generated_cts(
     """
     Run full CT generation evaluation.
 
-    This function produces three metric files:
+    This function produces up to three metric files:
 
     1. generated_vs_real_metrics.csv
        Generated CTs compared to original/reference CTs.
@@ -1031,7 +1033,7 @@ def evaluate_generated_cts(
         If generated or original CT directories do not exist.
 
     ValueError
-        If no valid comparisons can be calculated.
+        If no valid generated-vs-real comparisons can be calculated.
     """
 
     generated = collect_generated_cts(config.generated_ct_dir)

--- a/src/pipeline/evaluation/metrics.py
+++ b/src/pipeline/evaluation/metrics.py
@@ -304,25 +304,25 @@ def ssim_3d(pred: np.ndarray, ref: np.ndarray, data_min: float, data_max: float)
     """
 
     if pred.size == 0:
-        raise ValueError("`pred` cannot be empty.")
+        raise ValueError("`pred` cannot be empty")
 
     if ref.size == 0:
-        raise ValueError("`ref` cannot be empty.")
+        raise ValueError("`ref` cannot be empty")
 
     if pred.ndim != 3:
-        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}.")
+        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}")
 
     if ref.ndim != 3:
-        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}.")
+        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}")
 
     if pred.shape != ref.shape:
-        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}.")
+        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}")
 
     if not np.isfinite(pred).all():
-        raise ValueError("`pred` contains NaN or infinite values.")
+        raise ValueError("`pred` contains NaN or infinite values")
 
     if not np.isfinite(ref).all():
-        raise ValueError("`ref` contains NaN or infinite values.")
+        raise ValueError("`ref` contains NaN or infinite values")
 
     if data_min >= data_max:
         raise ValueError(f"`data_min` must be smaller than `data_max`. Got data_min={data_min}, data_max={data_max}")
@@ -385,13 +385,13 @@ def sobel_edge_map_3d(arr: np.ndarray) -> FloatArray:
     """
 
     if arr.size == 0:
-        raise ValueError("`arr` cannot be empty.")
+        raise ValueError("`arr` cannot be empty")
 
     if arr.ndim != 3:
         raise ValueError(f"`arr` must be a 3D array with shape [H, W, Z]. Got shape {arr.shape}")
 
     if not np.isfinite(arr).all():
-        raise ValueError("`arr` contains NaN or infinite values.")
+        raise ValueError("`arr` contains NaN or infinite values")
 
     sx = sobel(arr, axis=0)
     sy = sobel(arr, axis=1)
@@ -436,25 +436,25 @@ def sob_3d(pred: np.ndarray, ref: np.ndarray) -> float:
     """
 
     if pred.size == 0:
-        raise ValueError("`pred` cannot be empty.")
+        raise ValueError("`pred` cannot be empty")
 
     if ref.size == 0:
-        raise ValueError("`ref` cannot be empty.")
+        raise ValueError("`ref` cannot be empty")
 
     if pred.ndim != 3:
-        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}.")
+        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}")
 
     if ref.ndim != 3:
-        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}.")
+        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}")
 
     if pred.shape != ref.shape:
-        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}.")
+        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}")
 
     if not np.isfinite(pred).all():
-        raise ValueError("`pred` contains NaN or infinite values.")
+        raise ValueError("`pred` contains NaN or infinite values")
 
     if not np.isfinite(ref).all():
-        raise ValueError("`ref` contains NaN or infinite values.")
+        raise ValueError("`ref` contains NaN or infinite values")
 
     pred_edge = sobel_edge_map_3d(pred)
     ref_edge = sobel_edge_map_3d(ref)
@@ -501,19 +501,19 @@ def _evenly_spaced_slices_for_lpips(
     """
 
     if arr.size == 0:
-        raise ValueError("`arr` cannot be empty.")
+        raise ValueError("`arr` cannot be empty")
 
     if arr.ndim != 3:
         raise ValueError(f"`arr` must be a 3D array with shape [H, W, Z]. Got shape {arr.shape}")
 
     if not np.isfinite(arr).all():
-        raise ValueError("`arr` contains NaN or infinite values.")
+        raise ValueError("`arr` contains NaN or infinite values")
 
     if arr.min() < 0.0 or arr.max() > 1.0:
-        raise ValueError("`arr` must be normalized to [0, 1] before LPIPS calculation.")
+        raise ValueError("`arr` must be normalized to [0, 1] before LPIPS calculation")
 
     if max_slices < 1:
-        raise ValueError("`max_slices` must be at least 1.")
+        raise ValueError("`max_slices` must be at least 1")
 
     z_dim = arr.shape[-1]
 
@@ -1006,7 +1006,7 @@ def calculate_pairwise_variety_metrics(
             rows.append(row)
 
     if len(rows) == 0:
-        print(f"Skipping {comparison_type}: no valid pairwise comparisons were calculated.")
+        print(f"Skipping {comparison_type}: no valid pairwise comparisons were calculated")
         return
 
     df = pd.DataFrame(rows)

--- a/src/pipeline/helpers/helpers.py
+++ b/src/pipeline/helpers/helpers.py
@@ -1,0 +1,274 @@
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import numpy.typing as npt
+import torch
+
+FloatArray = npt.NDArray[np.floating[Any]]
+
+
+def _is_planning_ct_path(path: str | Path) -> bool:
+    """Determine whether a CT path identifies the planning scan.
+
+    A planning CT is identified by the ``"fraction_1_"`` marker in its
+    filename.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to a CT image.
+
+    Returns
+    -------
+    bool
+        ``True`` when the filename denotes a planning CT; otherwise, ``False``.
+    """
+
+    return "fraction_1_" in Path(path).name
+
+
+def _extract_all_ct_paths(data_path_list: list[str] | list[dict[str, Any]]) -> list[str]:
+    """
+    Extract all unique CT paths from the evaluation data list.
+
+    Assumptions:
+    - The data list may contain either raw path strings or dictionaries.
+    - If dictionaries are used, CT paths are read from "moving_image" and
+      "fixed_image" when present.
+
+    Parameters
+    ----------
+    data_path_list : list[str] | list[dict[str, Any]]
+        List of CT paths or dictionaries describing CT pairs.
+
+    Returns
+    -------
+    ct_paths : list[str]
+        List of unique paths pointing to CT images.
+
+    Raises
+    ------
+    ValueError
+        If an item in the data list has an unsupported format.
+    """
+
+    ct_paths: list[str] = []
+    seen_paths: set[str] = set()
+
+    for item in data_path_list:
+        if isinstance(item, str):
+            item_paths = [item]
+
+        elif isinstance(item, dict):
+            item_paths = [cast(str, item[key]) for key in ("moving_image", "fixed_image") if key in item]
+            if len(item_paths) == 0:
+                raise ValueError(
+                    "Expected dictionary item to contain at least one of 'moving_image' or 'fixed_image'. "
+                    f"Got keys: {list(item.keys())}"
+                )
+
+        else:
+            raise ValueError(f"Each test item must be either a string path or a dictionary. Got: {type(item)}")
+
+        for path in item_paths:
+            if path not in seen_paths:
+                ct_paths.append(path)
+                seen_paths.add(path)
+
+    return ct_paths
+
+
+def _to_numpy_hu(
+    tensor: torch.Tensor,
+    data_min: float,
+    data_max: float,
+) -> FloatArray:
+    """
+    Convert a CT tensor to a NumPy array of HU values rounded to the nearest integer.
+
+    This helper supports two expected intensity formats:
+    - tensors normalized to the range [0, 1]
+    - HU-like tensors in the range approximately [data_min, data_max]
+
+    If the tensor is already outside hu, it is returned rounded as a
+    float32 NumPy array. Otherwise, values are linearly rescaled from [0, 1] to [data_min, data_max].
+
+    Parameters
+    ----------
+    tensor : torch.Tensor
+        Input CT tensor.
+
+    data_min: float
+        Minimum value allowed for the data.
+
+    data_max: float
+        Maximum value allowed for the data.
+
+    Returns
+    -------
+    arr : np.ndarray
+        CT image as a float32 NumPy array normalized to [data_min, data_max].
+
+    Raises
+    ------
+    ValueError
+        If `tensor` is empty.
+        If `tensor` contains NaN or infinite values.
+        If `data_min` is more than `data_max`.
+    """
+
+    if tensor.numel() == 0:
+        raise ValueError("`tensor` cannot be empty")
+
+    if not torch.isfinite(tensor).all():
+        raise ValueError("`tensor` contains NaN or infinite values")
+
+    if data_min >= data_max:
+        raise ValueError(f"`data_min` must be smaller than `data_max`. Got data_min={data_min}, data_max={data_max}")
+
+    arr = tensor.detach().cpu().numpy().astype(np.float32)
+
+    # Case 1: HU-like range [data_min, data_max]
+    if arr.min() < 0.0 or arr.max() > 1.0:
+        return arr.round()
+
+    # Case 2: normalized to [0, 1]
+    arr = ((data_max - data_min) * arr + data_min).astype(np.float32).round()
+
+    return arr
+
+
+def _extract_patient_id(path: str | Path) -> str:
+    """
+    Extract patient ID from a CT tensor filename or generated output path.
+
+    Supported filename patterns:
+    - Planning CT / original CT:
+        Patient_1_fraction_1_.pt -> Patient_1
+    - Generated CT:
+        Patient_1_gen_1.pt -> Patient_1
+
+    If neither pattern is found, the parent folder name is returned as a
+    fallback. This supports folder-based generated outputs such as:
+        generated_ct/test/Patient_1/Patient_1_gen_1.pt
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to a CT tensor file.
+
+    Returns
+    -------
+    patient_id : str
+        Extracted patient ID.
+
+    Raises
+    ------
+    ValueError
+        If `path` is empty.
+        If patient ID cannot be extracted from the filename or parent folder.
+    """
+
+    path = Path(path)
+
+    if str(path).strip() == "":
+        raise ValueError("`path` cannot be empty")
+
+    name = path.name
+
+    if "_fraction_" in name:
+        patient_id = name.split("_fraction_")[0]
+
+    elif "_gen_" in name:
+        patient_id = name.split("_gen_")[0]
+
+    else:
+        # fallback for folder-based generated outputs
+        patient_id = path.parent.name
+
+    if patient_id == "":
+        raise ValueError(f"Could not extract patient ID from path: {path}")
+
+    if patient_id in {".", ".."}:
+        raise ValueError(f"Invalid patient ID extracted from path: {path}")
+
+    return patient_id
+
+
+def _exclude_planning_cts(ct_groups: dict[str, list[Path]]) -> dict[str, list[Path]]:
+    """Return CT groups with planning CT tensors removed.
+
+    The returned dictionary preserves every patient key and the order of each
+    patient's non-planning CT paths.
+
+    Parameters
+    ----------
+    ct_groups : dict[str, list[Path]]
+        CT tensor paths grouped by patient identifier.
+
+    Returns
+    -------
+    dict[str, list[Path]]
+        New patient groups containing only non-planning CT tensor paths.
+    """
+
+    return {
+        patient_id: [path for path in paths if not _is_planning_ct_path(path)]
+        for patient_id, paths in ct_groups.items()
+    }
+
+
+def _load_tensor(path: str | Path) -> torch.Tensor:
+    """
+    Load a tensor from a `.pt` file and normalize its shape.
+
+    This helper loads tensors saved by different stages of the MAISI testing
+    pipeline. It supports files that contain either a raw tensor or a
+    dictionary with an `"image"` key.
+
+    Shape handling:
+    - If the tensor has 5 dimensions, the first dimension is treated as a
+      batch dimension and removed.
+    - If the tensor has 4 dimensions, the first dimension is treated as a
+      channel dimension and removed.
+    - The returned tensor is always converted to float and moved to CPU.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the `.pt` tensor file.
+
+    Returns
+    -------
+    tensor : torch.Tensor
+        Loaded tensor as a CPU float tensor, usually with shape:
+        `(D, H, W)` or equivalent spatial dimensions.
+
+    Raises
+    ------
+    ValueError
+        If the loaded object is a dictionary but does not contain an `"image"`
+        key.
+    """
+    loaded = cast(torch.Tensor | dict[str, torch.Tensor], torch.load(path, weights_only=True))
+
+    if isinstance(loaded, dict):
+        if "image" in loaded:
+            tensor = loaded["image"]
+        else:
+            raise ValueError(f"Unsupported tensor dictionary keys: {loaded.keys()}")
+    else:
+        tensor = loaded
+
+    tensor = tensor.float()
+
+    # Remove batch dimension if present.
+    if tensor.ndim == 5:
+        tensor = tensor[0]
+
+    # Remove channel dimension if present.
+    if tensor.ndim == 4:
+        tensor = tensor[0]
+
+    return tensor.cpu()

--- a/src/pipeline/inference/encode_latents.py
+++ b/src/pipeline/inference/encode_latents.py
@@ -77,8 +77,8 @@ def build_processed_ct_loader(
     """
     Build a dataloader for processed planning CT tensors.
 
-    This function scans `config.processed_ct_dir` for `.pt` files and creates
-    a MONAI dataloader that loads them for VAE encoding.
+    This function scans `config.processed_ct_dir` for planning CT `.pt` files
+    and creates a MONAI dataloader that loads them for VAE encoding.
 
     Each sample has the format:
         {
@@ -89,6 +89,7 @@ def build_processed_ct_loader(
     Assumptions:
     - Processed CTs are stored in:
         config.processed_ct_dir
+    - Planning CTs are identified by "fraction_1_" in the filename.
     - Latent CTs should be saved to:
         config.latent_ct_dir
     - Processed CTs are saved as `.pt` files.
@@ -106,7 +107,7 @@ def build_processed_ct_loader(
     Returns
     -------
     loader : ThreadDataLoader
-        MONAI dataloader over processed CT tensors.
+        MONAI dataloader over processed planning CT tensors.
 
     Raises
     ------
@@ -114,7 +115,7 @@ def build_processed_ct_loader(
         If `config.processed_ct_dir` does not exist.
 
     ValueError
-        If no `.pt` files are found or batch size is invalid.
+        If no planning CT `.pt` files are found or batch size is invalid.
     """
 
     if batch_size < 1:
@@ -137,6 +138,9 @@ def build_processed_ct_loader(
     for file_path in sorted(glob.glob(str(config.processed_ct_dir / "*.pt"))):
         filename = os.path.basename(file_path)
 
+        if "fraction_1_" not in filename:
+            continue
+
         test_files.append(
             {
                 "image": file_path,
@@ -146,7 +150,8 @@ def build_processed_ct_loader(
 
     if len(test_files) == 0:
         raise ValueError(
-            f"No processed CT `.pt` files found in: {config.processed_ct_dir}. Run `prepare_test_data(config)` first"
+            f"No processed planning CT `.pt` files found in: {config.processed_ct_dir}. "
+            "Run `prepare_test_data(config)` first"
         )
 
     dataset = Dataset(data=test_files, transform=transform)
@@ -186,10 +191,10 @@ def encode_latents(config: MaisiTestingConfig) -> None:
     Raises
     ------
     FileNotFoundError
-        If processed CTs or VAE weights are missing.
+        If processed planning CTs or VAE weights are missing.
 
     ValueError
-        If no processed CTs are found or config values are invalid.
+        If no processed planning CTs are found or config values are invalid.
 
     RuntimeError
         If the VAE checkpoint is incompatible with the VAE config.


### PR DESCRIPTION
## Description

This PR fixes a pipeline bug where only planning CTs were saved during processing, resulting in a single real CT per patient and breaking metric computation. The pipeline now processes all CTs while continuing to encode only planning CTs as latents, since those are the only CTs used for inference.

## Related Issue

Closes #40

## Proposed Changes

- Updates the pipeline to process and save all CTs for each patient.
- Restricts latent encoding to planning CTs only.
- Preserves the existing inference behavior that relies exclusively on planning CT latents.
- Adjusts `generated_vs_real` and `real_vs_real` comparison metrics to exclude planning CT.