### PR TITLE
Change device to GPU (#44)

### DIFF
--- a/notebooks/pipeline_testing.ipynb
+++ b/notebooks/pipeline_testing.ipynb
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "id": "2f2a2496-c65a-4c2c-9906-2eda47a95262",
    "metadata": {},
    "outputs": [
@@ -153,7 +153,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Generated vs real metrics: 100%|████████████████████████████████████████████████████| 15/15 [1:52:26<00:00, 449.79s/it]\n",
+      "Generated vs real metrics: 100%|███████████████████████████████████████████████████████| 15/15 [06:12<00:00, 24.83s/it]\n",
       "C:\\Users\\Wiktoria\\Documents\\GitHub\\robust-radiotherapy-planning\\.venv\\Lib\\site-packages\\torchvision\\models\\_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.\n",
       "  warnings.warn(\n",
       "C:\\Users\\Wiktoria\\Documents\\GitHub\\robust-radiotherapy-planning\\.venv\\Lib\\site-packages\\torchvision\\models\\_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=AlexNet_Weights.IMAGENET1K_V1`. You can also use `weights=AlexNet_Weights.DEFAULT` to get the most up-to-date weights.\n",
@@ -172,28 +172,29 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "generated_vs_generated: 100%|██████████████████████████████████████████████████████████████████| 15/15 [00:00<?, ?it/s]"
+      "Generated pairwise variety metrics: 100%|████████████████████████████████████████████| 15/15 [00:00<00:00, 6389.21it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Skipping pairwise generated_vs_generated for Patient_01: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_10: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_15: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_16: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_17: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_23: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_26: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_40: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_41: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_46: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_51: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_52: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_59: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_72: only 1 image(s).\n",
-      "Skipping pairwise generated_vs_generated for Patient_73: only 1 image(s).\n"
+      "Skipping pairwise generated variety metrics for Patient_01: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_10: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_15: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_16: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_17: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_23: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_26: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_40: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_41: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_46: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_51: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_52: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_59: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_72: only 1 image(s).\n",
+      "Skipping pairwise generated variety metrics for Patient_73: only 1 image(s).\n",
+      "Skipping generated pairwise variety metrics: no valid pairwise comparisons were calculated\n"
      ]
     },
     {
@@ -201,19 +202,6 @@
      "output_type": "stream",
      "text": [
       "\n"
-     ]
-    },
-    {
-     "ename": "ValueError",
-     "evalue": "No valid pairwise comparisons were calculated for `generated_vs_generated`.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[8]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mevaluate_generated_cts\u001b[49m\u001b[43m(\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\Documents\\GitHub\\robust-radiotherapy-planning\\src\\pipeline\\evaluation\\metrics.py:1044\u001b[39m, in \u001b[36mevaluate_generated_cts\u001b[39m\u001b[34m(config)\u001b[39m\n\u001b[32m   1038\u001b[39m originals = collect_original_cts(config.processed_ct_dir)\n\u001b[32m   1040\u001b[39m calculate_similarity_metrics(\n\u001b[32m   1041\u001b[39m     config=config,\n\u001b[32m   1042\u001b[39m )\n\u001b[32m-> \u001b[39m\u001b[32m1044\u001b[39m \u001b[43mcalculate_pairwise_variety_metrics\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1045\u001b[39m \u001b[43m    \u001b[49m\u001b[43mct_groups\u001b[49m\u001b[43m=\u001b[49m\u001b[43mgenerated\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1046\u001b[39m \u001b[43m    \u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m=\u001b[49m\u001b[43mconfig\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1047\u001b[39m \u001b[43m    \u001b[49m\u001b[43moutput_filename\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mgenerated_pairwise_variety_metrics.csv\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   1048\u001b[39m \u001b[43m    \u001b[49m\u001b[43mcomparison_type\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mgenerated_vs_generated\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   1049\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1051\u001b[39m calculate_pairwise_variety_metrics(\n\u001b[32m   1052\u001b[39m     ct_groups=originals,\n\u001b[32m   1053\u001b[39m     config=config,\n\u001b[32m   1054\u001b[39m     output_filename=\u001b[33m\"\u001b[39m\u001b[33mreal_pairwise_variety_metrics.csv\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   1055\u001b[39m     comparison_type=\u001b[33m\"\u001b[39m\u001b[33mreal_vs_real\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m   1056\u001b[39m )\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~\\Documents\\GitHub\\robust-radiotherapy-planning\\src\\pipeline\\evaluation\\metrics.py:984\u001b[39m, in \u001b[36mcalculate_pairwise_variety_metrics\u001b[39m\u001b[34m(ct_groups, config, output_filename, comparison_type)\u001b[39m\n\u001b[32m    981\u001b[39m         rows.append(row)\n\u001b[32m    983\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(rows) == \u001b[32m0\u001b[39m:\n\u001b[32m--> \u001b[39m\u001b[32m984\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mNo valid pairwise comparisons were calculated for `\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcomparison_type\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m`.\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m    986\u001b[39m df = pd.DataFrame(rows)\n\u001b[32m    988\u001b[39m df.to_csv(\n\u001b[32m    989\u001b[39m     config.metrics_dir / output_filename,\n\u001b[32m    990\u001b[39m     index=\u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[32m    991\u001b[39m )\n",
-      "\u001b[31mValueError\u001b[39m: No valid pairwise comparisons were calculated for `generated_vs_generated`."
      ]
     }
    ],

--- a/src/pipeline/evaluation/metrics.py
+++ b/src/pipeline/evaluation/metrics.py
@@ -115,9 +115,7 @@ def ssim_3d(pred: MetricInput, ref: MetricInput, data_min: float, data_max: floa
     ref_max = float(ref_t.max().item())
 
     if pred_min < data_min or pred_max > data_max:
-        raise ValueError(
-            f"`pred` values must be in the range [data_min, data_max], got min={pred_min}, max={pred_max}"
-        )
+        raise ValueError(f"`pred` values must be in the range [data_min, data_max], got min={pred_min}, max={pred_max}")
 
     if ref_min < data_min or ref_max > data_max:
         raise ValueError(f"`ref` values must be in the range [data_min, data_max], got min={ref_min}, max={ref_max}")
@@ -200,9 +198,7 @@ def psnr_3d(pred: MetricInput, ref: MetricInput, data_min: float, data_max: floa
     ref_max = float(ref_t.max().item())
 
     if pred_min < data_min or pred_max > data_max:
-        raise ValueError(
-            f"`pred` values must be in the range [data_min, data_max], got min={pred_min}, max={pred_max}"
-        )
+        raise ValueError(f"`pred` values must be in the range [data_min, data_max], got min={pred_min}, max={pred_max}")
 
     if ref_min < data_min or ref_max > data_max:
         raise ValueError(f"`ref` values must be in the range [data_min, data_max], got min={ref_min}, max={ref_max}")

--- a/src/pipeline/evaluation/metrics.py
+++ b/src/pipeline/evaluation/metrics.py
@@ -148,7 +148,7 @@ def ssim_3d(pred: MetricInput, ref: MetricInput, data_min: float, data_max: floa
     return float(score.mean().item())
 
 
-def psnr_3d(pred: np.ndarray, ref: np.ndarray, data_min: float, data_max: float) -> float:
+def psnr_3d(pred: MetricInput, ref: MetricInput, data_min: float, data_max: float) -> float:
     """
     Calculate Peak Signal-to-Noise Ratio (PSNR) between two 3D images.
 
@@ -159,11 +159,11 @@ def psnr_3d(pred: np.ndarray, ref: np.ndarray, data_min: float, data_max: float)
 
     Parameters
     ----------
-    pred : np.ndarray
-        Predicted or generated 3D image array.
+    pred : np.ndarray | torch.Tensor
+        Predicted or generated 3D image.
 
-    ref : np.ndarray
-        Reference 3D image array.
+    ref : np.ndarray | torch.Tensor
+        Reference 3D image.
 
     data_min: float
         Minimum value allowed for the data.
@@ -187,51 +187,37 @@ def psnr_3d(pred: np.ndarray, ref: np.ndarray, data_min: float, data_max: float)
         If data falls outside of [data_min, data_max].
     """
 
-    if pred.size == 0:
-        raise ValueError("`pred` cannot be empty")
-
-    if ref.size == 0:
-        raise ValueError("`ref` cannot be empty")
-
-    if pred.ndim != 3:
-        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}")
-
-    if ref.ndim != 3:
-        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}")
-
-    if pred.shape != ref.shape:
-        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}")
-
-    if not np.isfinite(pred).all():
-        raise ValueError("`pred` contains NaN or infinite values")
-
-    if not np.isfinite(ref).all():
-        raise ValueError("`ref` contains NaN or infinite values")
+    pred_t = _as_metric_tensor(pred)
+    ref_t = _as_metric_tensor(ref, device=pred_t.device)
+    _validate_3d_pair(pred_t, ref_t)
 
     if data_min >= data_max:
         raise ValueError(f"`data_min` must be smaller than `data_max`. Got data_min={data_min}, data_max={data_max}")
 
-    if pred.min() < data_min or pred.max() > data_max:
+    pred_min = float(pred_t.min().item())
+    pred_max = float(pred_t.max().item())
+    ref_min = float(ref_t.min().item())
+    ref_max = float(ref_t.max().item())
+
+    if pred_min < data_min or pred_max > data_max:
         raise ValueError(
-            f"`pred` values must be in the range [data_min, data_max], got min={pred.min()}, max={pred.max()}"
+            f"`pred` values must be in the range [data_min, data_max], got min={pred_min}, max={pred_max}"
         )
 
-    if ref.min() < data_min or ref.max() > data_max:
-        raise ValueError(
-            f"`ref` values must be in the range [data_min, data_max], got min={ref.min()}, max={ref.max()}"
-        )
+    if ref_min < data_min or ref_max > data_max:
+        raise ValueError(f"`ref` values must be in the range [data_min, data_max], got min={ref_min}, max={ref_max}")
 
-    mse = float(np.mean((pred - ref) ** 2))
+    mse = torch.mean((pred_t - ref_t) ** 2)
 
-    if mse == 0.0:
+    if float(mse.item()) == 0.0:
         return float("inf")
 
     data_range = data_max - data_min
 
-    return float(10.0 * np.log10((data_range**2) / mse))
+    return float((10.0 * torch.log10(torch.tensor(data_range**2, device=pred_t.device) / mse)).item())
 
 
-def sobel_edge_map_3d(arr: np.ndarray) -> FloatArray:
+def sobel_edge_map_3d(arr: MetricInput) -> torch.Tensor:
     """
     Calculate a 3D Sobel edge magnitude map.
 

--- a/src/pipeline/evaluation/metrics.py
+++ b/src/pipeline/evaluation/metrics.py
@@ -6,17 +6,19 @@ from typing import Protocol, cast
 import numpy as np
 import pandas as pd
 import torch
-from scipy.ndimage import sobel
-from skimage.metrics import structural_similarity as ssim
+import torch.nn.functional as F
+from monai.metrics.regression import SSIMMetric
 from tqdm import tqdm
 
 from src.pipeline.config import MaisiTestingConfig
 from src.pipeline.helpers.helpers import (
-    FloatArray,
+    MetricInput,
+    _as_metric_tensor,
+    _cache_patient_cts,
+    _evenly_spaced_slices_for_lpips,
     _exclude_planning_cts,
     _extract_patient_id,
-    _load_tensor,
-    _to_numpy_hu,
+    _validate_3d_pair,
 )
 
 
@@ -24,7 +26,7 @@ class LPIPSModel(Protocol):
     def __call__(self, pred: torch.Tensor, ref: torch.Tensor) -> torch.Tensor: ...
 
 
-def mae_3d(pred: np.ndarray, ref: np.ndarray) -> float:
+def mae_3d(pred: MetricInput, ref: MetricInput) -> float:
     """
     Calculate mean absolute error between two 3D images.
 
@@ -33,11 +35,11 @@ def mae_3d(pred: np.ndarray, ref: np.ndarray) -> float:
 
     Parameters
     ----------
-    pred : np.ndarray
-        Predicted or generated 3D image array.
+    pred : np.ndarray | torch.Tensor
+        Predicted or generated 3D image.
 
-    ref : np.ndarray
-        Reference 3D image array.
+    ref : np.ndarray | torch.Tensor
+        Reference 3D image.
 
     Returns
     -------
@@ -53,31 +55,14 @@ def mae_3d(pred: np.ndarray, ref: np.ndarray) -> float:
         If `pred` or `ref` contains NaN or infinite values.
     """
 
-    if pred.size == 0:
-        raise ValueError("`pred` cannot be empty")
+    pred_t = _as_metric_tensor(pred)
+    ref_t = _as_metric_tensor(ref, device=pred_t.device)
+    _validate_3d_pair(pred_t, ref_t)
 
-    if ref.size == 0:
-        raise ValueError("`ref` cannot be empty")
-
-    if pred.ndim != 3:
-        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}")
-
-    if ref.ndim != 3:
-        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}")
-
-    if pred.shape != ref.shape:
-        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}")
-
-    if not np.isfinite(pred).all():
-        raise ValueError("`pred` contains NaN or infinite values")
-
-    if not np.isfinite(ref).all():
-        raise ValueError("`ref` contains NaN or infinite values")
-
-    return float(np.mean(np.abs(pred - ref)))
+    return float(torch.mean(torch.abs(pred_t - ref_t)).item())
 
 
-def ssim_3d(pred: np.ndarray, ref: np.ndarray, data_min: float, data_max: float) -> float:
+def ssim_3d(pred: MetricInput, ref: MetricInput, data_min: float, data_max: float) -> float:
     """
     Calculate the mean Structural Similarity Index (SSIM) for two 3D images.
 
@@ -88,11 +73,11 @@ def ssim_3d(pred: np.ndarray, ref: np.ndarray, data_min: float, data_max: float)
 
     Parameters
     ----------
-    pred : np.ndarray
-        Predicted 3D image array.
+    pred : np.ndarray | torch.Tensor
+        Predicted 3D image.
 
-    ref : np.ndarray
-        Reference (ground-truth) 3D image array.
+    ref : np.ndarray | torch.Tensor
+        Reference (ground-truth) 3D image.
 
     Returns
     -------
@@ -117,60 +102,53 @@ def ssim_3d(pred: np.ndarray, ref: np.ndarray, data_min: float, data_max: float)
         If data falls outside of [data_min, data_max].
     """
 
-    if pred.size == 0:
-        raise ValueError("`pred` cannot be empty")
-
-    if ref.size == 0:
-        raise ValueError("`ref` cannot be empty")
-
-    if pred.ndim != 3:
-        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}")
-
-    if ref.ndim != 3:
-        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}")
-
-    if pred.shape != ref.shape:
-        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}")
-
-    if not np.isfinite(pred).all():
-        raise ValueError("`pred` contains NaN or infinite values")
-
-    if not np.isfinite(ref).all():
-        raise ValueError("`ref` contains NaN or infinite values")
+    pred_t = _as_metric_tensor(pred)
+    ref_t = _as_metric_tensor(ref, device=pred_t.device)
+    _validate_3d_pair(pred_t, ref_t)
 
     if data_min >= data_max:
         raise ValueError(f"`data_min` must be smaller than `data_max`. Got data_min={data_min}, data_max={data_max}")
 
-    if pred.min() < data_min or pred.max() > data_max:
+    pred_min = float(pred_t.min().item())
+    pred_max = float(pred_t.max().item())
+    ref_min = float(ref_t.min().item())
+    ref_max = float(ref_t.max().item())
+
+    if pred_min < data_min or pred_max > data_max:
         raise ValueError(
-            f"`pred` values must be in the range [data_min, data_max], got min={pred.min()}, max={pred.max()}"
+            f"`pred` values must be in the range [data_min, data_max], got min={pred_min}, max={pred_max}"
         )
 
-    if ref.min() < data_min or ref.max() > data_max:
-        raise ValueError(
-            f"`ref` values must be in the range [data_min, data_max], got min={ref.min()}, max={ref.max()}"
-        )
+    if ref_min < data_min or ref_max > data_max:
+        raise ValueError(f"`ref` values must be in the range [data_min, data_max], got min={ref_min}, max={ref_max}")
 
-    scores = []
+    window_size = min(11, *(int(dim) for dim in pred_t.shape))
+    if window_size % 2 == 0:
+        window_size -= 1
 
-    for z in range(pred.shape[-1]):
-        pred_slice = pred[:, :, z]
-        ref_slice = ref[:, :, z]
+    if window_size < 3:
+        raise ValueError(f"SSIM window is invalid for image shape {tuple(pred_t.shape)}")
 
+    metric = SSIMMetric(
+        spatial_dims=3,
+        data_range=data_max - data_min,
+        kernel_type="uniform",
+        win_size=window_size,
+    )
+
+    with torch.no_grad():
         score = cast(
-            float,
-            ssim(  # type: ignore[no-untyped-call]
-                ref_slice,
-                pred_slice,
-                data_range=data_max - data_min,
+            torch.Tensor,
+            metric(
+                pred_t.unsqueeze(0).unsqueeze(0),
+                ref_t.unsqueeze(0).unsqueeze(0),
             ),
         )
-        scores.append(score)
 
-    return float(np.mean(scores))
+    return float(score.mean().item())
 
 
-def sobel_edge_map_3d(arr: np.ndarray) -> FloatArray:
+def sobel_edge_map_3d(arr: MetricInput) -> torch.Tensor:
     """
     Calculate a 3D Sobel edge magnitude map.
 
@@ -182,13 +160,13 @@ def sobel_edge_map_3d(arr: np.ndarray) -> FloatArray:
 
     Parameters
     ----------
-    arr : np.ndarray
-        Input 3D image array.
+    arr : np.ndarray | torch.Tensor
+        Input 3D image.
 
     Returns
     -------
-    edge : np.ndarray
-        3D Sobel edge magnitude map as a float32 NumPy array.
+    edge : torch.Tensor
+        3D Sobel edge magnitude map.
 
     Raises
     ------
@@ -198,25 +176,32 @@ def sobel_edge_map_3d(arr: np.ndarray) -> FloatArray:
         If `arr` contains NaN or infinite values.
     """
 
-    if arr.size == 0:
+    arr_t = _as_metric_tensor(arr)
+
+    if arr_t.numel() == 0:
         raise ValueError("`arr` cannot be empty")
 
-    if arr.ndim != 3:
-        raise ValueError(f"`arr` must be a 3D array with shape [H, W, Z]. Got shape {arr.shape}")
+    if arr_t.ndim != 3:
+        raise ValueError(f"`arr` must be a 3D tensor with shape [H, W, Z]. Got shape {tuple(arr_t.shape)}")
 
-    if not np.isfinite(arr).all():
+    if not torch.isfinite(arr_t).all():
         raise ValueError("`arr` contains NaN or infinite values")
 
-    sx = sobel(arr, axis=0)
-    sy = sobel(arr, axis=1)
-    sz = sobel(arr, axis=2)
+    derivative = torch.tensor([-1.0, 0.0, 1.0], dtype=arr_t.dtype, device=arr_t.device)
+    smoothing = torch.tensor([1.0, 2.0, 1.0], dtype=arr_t.dtype, device=arr_t.device)
 
-    edge = np.sqrt(sx**2 + sy**2 + sz**2)
+    kernel_x = derivative[:, None, None] * smoothing[None, :, None] * smoothing[None, None, :]
+    kernel_y = smoothing[:, None, None] * derivative[None, :, None] * smoothing[None, None, :]
+    kernel_z = smoothing[:, None, None] * smoothing[None, :, None] * derivative[None, None, :]
+    kernels = torch.stack([kernel_x, kernel_y, kernel_z]).unsqueeze(1)
 
-    return cast(FloatArray, edge.astype(np.float32))
+    volume = arr_t.unsqueeze(0).unsqueeze(0)
+    gradients = F.conv3d(volume, kernels, padding=1)
+
+    return cast(torch.Tensor, torch.linalg.vector_norm(gradients.squeeze(0), dim=0))
 
 
-def sob_3d(pred: np.ndarray, ref: np.ndarray) -> float:
+def sob_3d(pred: MetricInput, ref: MetricInput) -> float:
     """
     Calculate SOB / Sobel-based edge difference between two 3D images.
 
@@ -229,11 +214,11 @@ def sob_3d(pred: np.ndarray, ref: np.ndarray) -> float:
 
     Parameters
     ----------
-    pred : np.ndarray
-        Predicted or generated 3D image array.
+    pred : np.ndarray | torch.Tensor
+        Predicted or generated 3D image.
 
-    ref : np.ndarray
-        Reference 3D image array.
+    ref : np.ndarray | torch.Tensor
+        Reference 3D image.
 
     Returns
     -------
@@ -249,115 +234,21 @@ def sob_3d(pred: np.ndarray, ref: np.ndarray) -> float:
         If `pred` or `ref` contains NaN or infinite values.
     """
 
-    if pred.size == 0:
-        raise ValueError("`pred` cannot be empty")
+    pred_t = _as_metric_tensor(pred)
+    ref_t = _as_metric_tensor(ref, device=pred_t.device)
+    _validate_3d_pair(pred_t, ref_t)
 
-    if ref.size == 0:
-        raise ValueError("`ref` cannot be empty")
+    pred_edge = sobel_edge_map_3d(pred_t)
+    ref_edge = sobel_edge_map_3d(ref_t)
 
-    if pred.ndim != 3:
-        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}")
-
-    if ref.ndim != 3:
-        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}")
-
-    if pred.shape != ref.shape:
-        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}")
-
-    if not np.isfinite(pred).all():
-        raise ValueError("`pred` contains NaN or infinite values")
-
-    if not np.isfinite(ref).all():
-        raise ValueError("`ref` contains NaN or infinite values")
-
-    pred_edge = sobel_edge_map_3d(pred)
-    ref_edge = sobel_edge_map_3d(ref)
-
-    return float(np.mean(np.abs(pred_edge - ref_edge)))
-
-
-def _evenly_spaced_slices_for_lpips(
-    arr: np.ndarray,
-    max_slices: int = 32,
-) -> torch.Tensor:
-    """
-    Extract evenly spaced 2D CT slices for LPIPS input format.
-
-    LPIPS expects 2D RGB-like images, so this function:
-    - selects up to `max_slices` slices evenly across the full 3D volume
-    - converts slices from shape [H, W, Z] to [Z, H, W]
-    - adds a channel dimension
-    - repeats the single CT channel into 3 channels
-    - rescales values from [0, 1] to [-1, 1]
-
-    Parameters
-    ----------
-    arr : np.ndarray
-        Input 3D CT array normalized to [0, 1], expected shape [H, W, Z].
-
-    max_slices : int
-        Maximum number of evenly spaced slices used for LPIPS calculation.
-
-    Returns
-    -------
-    tensor : torch.Tensor
-        Tensor formatted for LPIPS with shape [N, 3, H, W] and range [-1, 1],
-        where N is the number of selected slices.
-
-    Raises
-    ------
-    ValueError
-        If `arr` is empty.
-        If `arr` is not 3-dimensional.
-        If `arr` contains NaN or infinite values.
-        If `arr` is not normalized to [0, 1].
-        If `max_slices` is less than 1.
-    """
-
-    if arr.size == 0:
-        raise ValueError("`arr` cannot be empty")
-
-    if arr.ndim != 3:
-        raise ValueError(f"`arr` must be a 3D array with shape [H, W, Z]. Got shape {arr.shape}")
-
-    if not np.isfinite(arr).all():
-        raise ValueError("`arr` contains NaN or infinite values")
-
-    if arr.min() < 0.0 or arr.max() > 1.0:
-        raise ValueError("`arr` must be normalized to [0, 1] before LPIPS calculation")
-
-    if max_slices < 1:
-        raise ValueError("`max_slices` must be at least 1")
-
-    z_dim = arr.shape[-1]
-
-    if z_dim <= max_slices:
-        slice_ids = np.arange(z_dim)
-    else:
-        slice_ids = np.linspace(
-            0,
-            z_dim - 1,
-            num=max_slices,
-            dtype=int,
-        )
-
-    slices = arr[:, :, slice_ids]  # H, W, Z
-    slices = np.moveaxis(slices, -1, 0)  # Z, H, W
-
-    tensor = torch.from_numpy(slices).float()
-    tensor = tensor.unsqueeze(1)  # Z, 1, H, W
-    tensor = tensor.repeat(1, 3, 1, 1)  # Z, 3, H, W
-
-    tensor = tensor * 2.0 - 1.0
-
-    return tensor
+    return float(torch.mean(torch.abs(pred_edge - ref_edge)).item())
 
 
 def lpips_3d(
     config: MaisiTestingConfig,
     lpips_model: LPIPSModel,
-    pred: np.ndarray,
-    ref: np.ndarray,
+    pred: MetricInput,
+    ref: MetricInput,
 ) -> float:
     """
     Calculate slice-wise LPIPS between two 3D images and average the result.
@@ -384,10 +275,10 @@ def lpips_3d(
     lpips_model : LPIPSModel
         Initialized LPIPS model.
 
-    pred : np.ndarray
+    pred : np.ndarray | torch.Tensor
         Predicted or generated 3D CT array normalized to [data_min, data_max].
 
-    ref : np.ndarray
+    ref : np.ndarray | torch.Tensor
         Reference 3D CT array normalized to [data_min, data_max].
 
     Returns
@@ -406,42 +297,26 @@ def lpips_3d(
         If `max_slices` is less than 1.
     """
 
-    if pred.size == 0:
-        raise ValueError("`pred` cannot be empty")
+    device = torch.device(config.device)
+    pred_t = _as_metric_tensor(pred, device=device)
+    ref_t = _as_metric_tensor(ref, device=device)
+    _validate_3d_pair(pred_t, ref_t)
 
-    if ref.size == 0:
-        raise ValueError("`ref` cannot be empty")
-
-    if pred.ndim != 3:
-        raise ValueError(f"`pred` must be a 3D array. Got shape {pred.shape}")
-
-    if ref.ndim != 3:
-        raise ValueError(f"`ref` must be a 3D array. Got shape {ref.shape}")
-
-    if pred.shape != ref.shape:
-        raise ValueError(f"`pred` and `ref` must have the same shape. Got {pred.shape} and {ref.shape}")
-
-    if not np.isfinite(pred).all():
-        raise ValueError("`pred` contains NaN or infinite values")
-
-    if not np.isfinite(ref).all():
-        raise ValueError("`ref` contains NaN or infinite values")
-
-    if pred.min() < config.data_min or pred.max() > config.data_max:
+    if pred_t.min() < config.data_min or pred_t.max() > config.data_max:
         raise ValueError("`pred` must be normalized to [data_min, data_max]")
 
-    if ref.min() < config.data_min or ref.max() > config.data_max:
+    if ref_t.min() < config.data_min or ref_t.max() > config.data_max:
         raise ValueError("`ref` must be normalized to [data_min, data_max]")
 
     pred_tensor = _evenly_spaced_slices_for_lpips(
-        (pred - config.data_min) / (config.data_max - config.data_min),
+        (pred_t - config.data_min) / (config.data_max - config.data_min),
         max_slices=config.max_lpips_slices,
-    ).to(config.device)
+    )
 
     ref_tensor = _evenly_spaced_slices_for_lpips(
-        (ref - config.data_min) / (config.data_max - config.data_min),
+        (ref_t - config.data_min) / (config.data_max - config.data_min),
         max_slices=config.max_lpips_slices,
-    ).to(config.device)
+    )
 
     with torch.no_grad():
         score = lpips_model(pred_tensor, ref_tensor)
@@ -620,6 +495,7 @@ def calculate_similarity_metrics(
 
     generated = collect_generated_cts(config.generated_ct_dir)
     originals = collect_original_cts(config.processed_ct_dir)
+    device = torch.device(config.device)
 
     lpips_model = None
 
@@ -646,25 +522,19 @@ def calculate_similarity_metrics(
             print(f"Skipping {patient_id}: no non-planning original/reference CT found")
             continue
 
-        for gen_path in gen_paths:
-            gen_arr = _to_numpy_hu(
-                _load_tensor(gen_path),
-                data_min=config.data_min,
-                data_max=config.data_max,
-            )
+        patient_paths = [*gen_paths, *ref_paths]
+        patient_tensors = _cache_patient_cts(patient_paths, config=config, device=device)
 
+        for gen_path in gen_paths:
+            gen_arr = patient_tensors[gen_path]
             for ref_path in ref_paths:
-                ref_arr = _to_numpy_hu(
-                    _load_tensor(ref_path),
-                    data_min=config.data_min,
-                    data_max=config.data_max,
-                )
+                ref_arr = patient_tensors[ref_path]
 
                 if gen_arr.shape != ref_arr.shape:
                     print(
                         f"Skipping shape mismatch for {patient_id}: "
-                        f"{gen_path.name} {gen_arr.shape} vs "
-                        f"{ref_path.name} {ref_arr.shape}"
+                        f"{gen_path.name} {tuple(gen_arr.shape)} vs "
+                        f"{ref_path.name} {tuple(ref_arr.shape)}"
                     )
                     continue
 
@@ -714,15 +584,12 @@ def calculate_pairwise_variety_metrics(
     ct_groups: dict[str, list[Path]],
     config: MaisiTestingConfig,
     output_filename: str,
-    comparison_type: str,
 ) -> None:
     """
     Calculate pairwise variety metrics within groups of CT images.
 
-    This function compares all possible image pairs within each patient group.
-    It is used to estimate within-group variety, for example:
-    - real_vs_real: real fraction vs real fraction
-    - generated_vs_generated: generated variant vs generated variant
+    This function compares all possible generated image pairs within each
+    patient group.
 
     Metrics:
     - MAE: lower means more similar voxel intensities
@@ -741,10 +608,6 @@ def calculate_pairwise_variety_metrics(
     output_filename : str
         Name of the per-comparison output CSV file.
 
-    comparison_type : str
-        Label describing the comparison type, e.g.:
-        "generated_vs_generated" or "real_vs_real".
-
     Raises
     ------
     ValueError
@@ -758,6 +621,7 @@ def calculate_pairwise_variety_metrics(
     if len(ct_groups) == 0:
         raise ValueError("`ct_groups` cannot be empty")
 
+    device = torch.device(config.device)
     lpips_model = None
 
     if config.use_lpips:
@@ -771,35 +635,28 @@ def calculate_pairwise_variety_metrics(
             config.use_lpips = False
 
     rows = []
+    desc = "Generated pairwise variety metrics"
 
-    for patient_id, paths in tqdm(ct_groups.items(), desc=comparison_type):
+    for patient_id, paths in tqdm(ct_groups.items(), desc=desc):
         if len(paths) < 2:
-            print(f"Skipping pairwise {comparison_type} for {patient_id}: only {len(paths)} image(s).")
+            print(f"Skipping pairwise generated variety metrics for {patient_id}: only {len(paths)} image(s).")
             continue
 
-        for path_a, path_b in itertools.combinations(paths, 2):
-            arr_a = _to_numpy_hu(
-                _load_tensor(path_a),
-                data_min=config.data_min,
-                data_max=config.data_max,
-            )
-            arr_b = _to_numpy_hu(
-                _load_tensor(path_b),
-                data_min=config.data_min,
-                data_max=config.data_max,
-            )
+        patient_tensors = _cache_patient_cts(paths, config=config, device=device)
 
+        for path_a, path_b in itertools.combinations(paths, 2):
+            arr_a = patient_tensors[path_a]
+            arr_b = patient_tensors[path_b]
             if arr_a.shape != arr_b.shape:
                 print(
                     f"Skipping shape mismatch for {patient_id}: "
-                    f"{path_a.name} {arr_a.shape} vs "
-                    f"{path_b.name} {arr_b.shape}"
+                    f"{path_a.name} {tuple(arr_a.shape)} vs "
+                    f"{path_b.name} {tuple(arr_b.shape)}"
                 )
                 continue
 
             row = {
                 "patient_id": patient_id,
-                "comparison_type": comparison_type,
                 "path_a": str(path_a),
                 "path_b": str(path_b),
                 "mae": mae_3d(arr_a, arr_b),
@@ -820,7 +677,7 @@ def calculate_pairwise_variety_metrics(
             rows.append(row)
 
     if len(rows) == 0:
-        print(f"Skipping {comparison_type}: no valid pairwise comparisons were calculated")
+        print("Skipping generated pairwise variety metrics: no valid pairwise comparisons were calculated")
         return
 
     df = pd.DataFrame(rows)
@@ -842,7 +699,7 @@ def evaluate_generated_cts(
     """
     Run full CT generation evaluation.
 
-    This function produces up to three metric files:
+    This function produces up to two metric files:
 
     1. generated_vs_real_metrics.csv
        Generated CTs compared to original/reference CTs.
@@ -850,12 +707,9 @@ def evaluate_generated_cts(
     2. generated_pairwise_variety_metrics.csv
        Generated CT variants compared with each other.
 
-    3. real_pairwise_variety_metrics.csv
-       Real/reference CTs compared with each other.
-
     The goal is to check:
     - whether generated CTs are similar to real CTs
-    - whether generated variety is comparable to real anatomical variety
+    - whether generated variants are diverse relative to each other
 
     Parameters
     ----------
@@ -875,8 +729,6 @@ def evaluate_generated_cts(
     """
 
     generated = collect_generated_cts(config.generated_ct_dir)
-    originals = collect_original_cts(config.processed_ct_dir)
-    originals_without_planning = _exclude_planning_cts(originals)
 
     calculate_similarity_metrics(
         config=config,
@@ -886,12 +738,4 @@ def evaluate_generated_cts(
         ct_groups=generated,
         config=config,
         output_filename="generated_pairwise_variety_metrics.csv",
-        comparison_type="generated_vs_generated",
-    )
-
-    calculate_pairwise_variety_metrics(
-        ct_groups=originals_without_planning,
-        config=config,
-        output_filename="real_pairwise_variety_metrics.csv",
-        comparison_type="real_vs_real",
     )

--- a/src/pipeline/helpers/helpers.py
+++ b/src/pipeline/helpers/helpers.py
@@ -2,10 +2,11 @@ from pathlib import Path
 from typing import Any, cast
 
 import numpy as np
-import numpy.typing as npt
 import torch
 
-FloatArray = npt.NDArray[np.floating[Any]]
+from src.pipeline.config import MaisiTestingConfig
+
+MetricInput = torch.Tensor | np.ndarray
 
 
 def _is_planning_ct_path(path: str | Path) -> bool:
@@ -77,66 +78,6 @@ def _extract_all_ct_paths(data_path_list: list[str] | list[dict[str, Any]]) -> l
                 seen_paths.add(path)
 
     return ct_paths
-
-
-def _to_numpy_hu(
-    tensor: torch.Tensor,
-    data_min: float,
-    data_max: float,
-) -> FloatArray:
-    """
-    Convert a CT tensor to a NumPy array of HU values rounded to the nearest integer.
-
-    This helper supports two expected intensity formats:
-    - tensors normalized to the range [0, 1]
-    - HU-like tensors in the range approximately [data_min, data_max]
-
-    If the tensor is already outside hu, it is returned rounded as a
-    float32 NumPy array. Otherwise, values are linearly rescaled from [0, 1] to [data_min, data_max].
-
-    Parameters
-    ----------
-    tensor : torch.Tensor
-        Input CT tensor.
-
-    data_min: float
-        Minimum value allowed for the data.
-
-    data_max: float
-        Maximum value allowed for the data.
-
-    Returns
-    -------
-    arr : np.ndarray
-        CT image as a float32 NumPy array normalized to [data_min, data_max].
-
-    Raises
-    ------
-    ValueError
-        If `tensor` is empty.
-        If `tensor` contains NaN or infinite values.
-        If `data_min` is more than `data_max`.
-    """
-
-    if tensor.numel() == 0:
-        raise ValueError("`tensor` cannot be empty")
-
-    if not torch.isfinite(tensor).all():
-        raise ValueError("`tensor` contains NaN or infinite values")
-
-    if data_min >= data_max:
-        raise ValueError(f"`data_min` must be smaller than `data_max`. Got data_min={data_min}, data_max={data_max}")
-
-    arr = tensor.detach().cpu().numpy().astype(np.float32)
-
-    # Case 1: HU-like range [data_min, data_max]
-    if arr.min() < 0.0 or arr.max() > 1.0:
-        return arr.round()
-
-    # Case 2: normalized to [0, 1]
-    arr = ((data_max - data_min) * arr + data_min).astype(np.float32).round()
-
-    return arr
 
 
 def _extract_patient_id(path: str | Path) -> str:
@@ -263,12 +204,278 @@ def _load_tensor(path: str | Path) -> torch.Tensor:
 
     tensor = tensor.float()
 
-    # Remove batch dimension if present.
+    # Remove batch dimension if present
     if tensor.ndim == 5:
         tensor = tensor[0]
 
-    # Remove channel dimension if present.
+    # Remove channel dimension if present
     if tensor.ndim == 4:
         tensor = tensor[0]
 
     return tensor.cpu()
+
+
+def _as_metric_tensor(value: MetricInput, device: torch.device | str | None = None) -> torch.Tensor:
+    """
+    Convert a metric input to a float tensor on an optional target device.
+
+    Parameters
+    ----------
+    value : torch.Tensor | np.ndarray
+        Input image or volume used by metric calculations.
+
+    device : torch.device | str | None, optional
+        Device to move the returned tensor to. If ``None``, tensors stay on
+        their current device and NumPy arrays remain on CPU.
+
+    Returns
+    -------
+    torch.Tensor
+        Detached float tensor suitable for metric calculations.
+    """
+
+    if isinstance(value, np.ndarray):
+        tensor = torch.from_numpy(value)
+    else:
+        tensor = value.detach()
+
+    tensor = tensor.float()
+
+    if device is not None:
+        tensor = tensor.to(device)
+
+    return tensor
+
+
+def _validate_3d_pair(pred: torch.Tensor, ref: torch.Tensor) -> None:
+    """
+    Validate two 3D metric tensors before comparing them.
+
+    Parameters
+    ----------
+    pred : torch.Tensor
+        Predicted or generated 3D image tensor.
+
+    ref : torch.Tensor
+        Reference 3D image tensor.
+
+    Raises
+    ------
+    ValueError
+        If either tensor is empty, not 3D, shape-mismatched, or contains NaN
+        or infinite values.
+    """
+
+    if pred.numel() == 0:
+        raise ValueError("`pred` cannot be empty")
+
+    if ref.numel() == 0:
+        raise ValueError("`ref` cannot be empty")
+
+    if pred.ndim != 3:
+        raise ValueError(f"`pred` must be a 3D tensor. Got shape {tuple(pred.shape)}")
+
+    if ref.ndim != 3:
+        raise ValueError(f"`ref` must be a 3D tensor. Got shape {tuple(ref.shape)}")
+
+    if pred.shape != ref.shape:
+        raise ValueError(f"`pred` and `ref` must have the same shape. Got {tuple(pred.shape)} and {tuple(ref.shape)}")
+
+    if not torch.isfinite(pred).all():
+        raise ValueError("`pred` contains NaN or infinite values")
+
+    if not torch.isfinite(ref).all():
+        raise ValueError("`ref` contains NaN or infinite values")
+
+
+def _to_tensor_hu(
+    tensor: torch.Tensor,
+    data_min: float,
+    data_max: float,
+    device: torch.device | str,
+) -> torch.Tensor:
+    """
+    Convert a CT tensor to rounded HU values on a target device.
+
+    This helper supports tensors already in HU-like units as well as tensors
+    normalized to ``[0, 1]``. Normalized tensors are linearly rescaled to
+    ``[data_min, data_max]``.
+
+    Parameters
+    ----------
+    tensor : torch.Tensor
+        Input CT tensor.
+
+    data_min : float
+        Minimum HU value represented by normalized input tensors.
+
+    data_max : float
+        Maximum HU value represented by normalized input tensors.
+
+    device : torch.device | str
+        Device where the returned tensor should live.
+
+    Returns
+    -------
+    torch.Tensor
+        Float tensor of rounded HU values on ``device``.
+
+    Raises
+    ------
+    ValueError
+        If the tensor is empty, contains non-finite values, or ``data_min`` is
+        greater than or equal to ``data_max``.
+    """
+
+    if tensor.numel() == 0:
+        raise ValueError("`tensor` cannot be empty")
+
+    tensor = tensor.detach().float().to(device)
+
+    if not torch.isfinite(tensor).all():
+        raise ValueError("`tensor` contains NaN or infinite values")
+
+    if data_min >= data_max:
+        raise ValueError(f"`data_min` must be smaller than `data_max`. Got data_min={data_min}, data_max={data_max}")
+
+    if tensor.min() < 0.0 or tensor.max() > 1.0:
+        return tensor.round()
+
+    return ((data_max - data_min) * tensor + data_min).round()
+
+
+def _load_hu_tensor(
+    path: Path,
+    config: MaisiTestingConfig,
+    device: torch.device,
+) -> torch.Tensor:
+    """
+    Load one CT tensor file and convert it to HU values on a target device.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the saved CT tensor.
+
+    config : MaisiTestingConfig
+        Pipeline configuration containing CT intensity range settings.
+
+    device : torch.device
+        Device where the returned tensor should be cached.
+
+    Returns
+    -------
+    torch.Tensor
+        CT tensor in rounded HU values on ``device``.
+    """
+
+    return _to_tensor_hu(
+        _load_tensor(path),
+        data_min=config.data_min,
+        data_max=config.data_max,
+        device=device,
+    )
+
+
+def _cache_patient_cts(
+    paths: list[Path],
+    config: MaisiTestingConfig,
+    device: torch.device,
+) -> dict[Path, torch.Tensor]:
+    """
+    Load all CT tensors for one patient into device memory.
+
+    Parameters
+    ----------
+    paths : list[Path]
+        CT tensor paths for a single patient.
+
+    config : MaisiTestingConfig
+        Pipeline configuration containing CT intensity range settings.
+
+    device : torch.device
+        Device used for metric calculation and cache storage.
+
+    Returns
+    -------
+    dict[Path, torch.Tensor]
+        Mapping from each input path to its loaded HU tensor on ``device``.
+    """
+
+    return {path: _load_hu_tensor(path, config=config, device=device) for path in paths}
+
+
+def _evenly_spaced_slices_for_lpips(
+    arr: MetricInput,
+    max_slices: int = 32,
+) -> torch.Tensor:
+    """
+    Extract evenly spaced 2D CT slices for LPIPS input format.
+
+    LPIPS expects 2D RGB-like images, so this function:
+    - selects up to `max_slices` slices evenly across the full 3D volume
+    - converts slices from shape [H, W, Z] to [Z, H, W]
+    - adds a channel dimension
+    - repeats the single CT channel into 3 channels
+    - rescales values from [0, 1] to [-1, 1]
+
+    Parameters
+    ----------
+    arr : np.ndarray | torch.Tensor
+        Input 3D CT array normalized to [0, 1], expected shape [H, W, Z].
+
+    max_slices : int
+        Maximum number of evenly spaced slices used for LPIPS calculation.
+
+    Returns
+    -------
+    tensor : torch.Tensor
+        Tensor formatted for LPIPS with shape [N, 3, H, W] and range [-1, 1],
+        where N is the number of selected slices.
+
+    Raises
+    ------
+    ValueError
+        If `arr` is empty.
+        If `arr` is not 3-dimensional.
+        If `arr` contains NaN or infinite values.
+        If `arr` is not normalized to [0, 1].
+        If `max_slices` is less than 1.
+    """
+
+    arr_t = _as_metric_tensor(arr)
+
+    if arr_t.numel() == 0:
+        raise ValueError("`arr` cannot be empty")
+
+    if arr_t.ndim != 3:
+        raise ValueError(f"`arr` must be a 3D tensor with shape [H, W, Z]. Got shape {tuple(arr_t.shape)}")
+
+    if not torch.isfinite(arr_t).all():
+        raise ValueError("`arr` contains NaN or infinite values")
+
+    if arr_t.min() < 0.0 or arr_t.max() > 1.0:
+        raise ValueError("`arr` must be normalized to [0, 1] before LPIPS calculation")
+
+    if max_slices < 1:
+        raise ValueError("`max_slices` must be at least 1")
+
+    z_dim = int(arr_t.shape[-1])
+
+    if z_dim <= max_slices:
+        slice_ids = torch.arange(z_dim, device=arr_t.device)
+    else:
+        slice_ids = torch.linspace(
+            0,
+            z_dim - 1,
+            steps=max_slices,
+            device=arr_t.device,
+        ).long()
+
+    tensor = arr_t.index_select(dim=2, index=slice_ids)
+    tensor = tensor.permute(2, 0, 1).unsqueeze(1)  # Z, 1, H, W
+    tensor = tensor.repeat(1, 3, 1, 1)  # Z, 3, H, W
+
+    tensor = tensor * 2.0 - 1.0
+
+    return tensor


### PR DESCRIPTION
## Description

This PR improves the performance of the evaluation pipeline by removing major bottlenecks in metric computation. Metric calculation previously relied on single-core CPU execution, making evaluation significantly slower than image generation itself. The updated implementation performs metric computation on the configured device, reduces redundant data transfers through caching, and removes unnecessary metric calculations.

## Related Issue

Closes #44

## Proposed Changes
* Switches metric computation to use PyTorch on the device specified in the configuration.
* Caches all original and generated CT volumes for each patient in device memory during pairwise metric computation to avoid repeated transfers.
* Removes the `real_vs_real` metric calculation from the evaluation pipeline.