### PR TITLE
Add directory cleaning (#50)

### DIFF
--- a/src/pipeline/cli.py
+++ b/src/pipeline/cli.py
@@ -210,7 +210,7 @@ def run_stage(
 
     Parameters
     ----------
-    stage : Literal["prepare", "encode", "generate", "evaluate", "all"]
+    stage : PipelineStage
         Pipeline stage to run.
 
     config : MaisiTestingConfig

--- a/src/pipeline/cli.py
+++ b/src/pipeline/cli.py
@@ -8,6 +8,8 @@ from src.pipeline.evaluation.metrics import evaluate_generated_cts
 from src.pipeline.inference.encode_latents import encode_latents
 from src.pipeline.inference.run_generation import generate_ct_variants
 
+PipelineStage = Literal["prepare", "encode", "generate", "evaluate", "all"]
+
 
 def parse_args() -> argparse.Namespace:
     """
@@ -188,11 +190,16 @@ def build_config(args: argparse.Namespace) -> MaisiTestingConfig:
 
 
 def run_stage(
-    stage: Literal["prepare", "encode", "generate", "evaluate", "all"],
+    stage: PipelineStage,
     config: MaisiTestingConfig,
 ) -> None:
     """
     Run one selected MAISI testing pipeline stage.
+
+    Each stage entry point clears only the output directory it owns before
+    saving new results. This keeps single-stage runs usable: inputs produced by
+    earlier stages are preserved, while stale outputs for the selected stage are
+    removed by the function that writes them.
 
     Supported stages:
     - prepare: preprocess test CTs

--- a/src/pipeline/data/prepare_test_data.py
+++ b/src/pipeline/data/prepare_test_data.py
@@ -199,6 +199,8 @@ def prepare_test_data(
         If the processed CT output directory cannot be cleared.
     """
 
+    clear_directory_contents(config.processed_ct_dir)
+
     data_dict = create_data_split_dict(
         seed=seed,
         train_fraction=train_fraction,
@@ -229,8 +231,6 @@ def prepare_test_data(
         raise ValueError(
             f"The {config.evaluation_split} split is empty. Cannot prepare MAISI {config.evaluation_split} data"
         )
-
-    clear_directory_contents(config.processed_ct_dir)
 
     process_and_save_cts(
         config=config,

--- a/src/pipeline/data/prepare_test_data.py
+++ b/src/pipeline/data/prepare_test_data.py
@@ -16,6 +16,7 @@ from tqdm import tqdm
 
 from src.data_utils import create_data_split_dict
 from src.pipeline.config import MaisiTestingConfig
+from src.pipeline.helpers.cleanup import clear_directory_contents
 from src.pipeline.helpers.helpers import _extract_all_ct_paths
 
 
@@ -149,6 +150,7 @@ def prepare_test_data(
     - creates or loads the longitudinal CT train/validation/test split
     - selects the configured test or validation split
     - extracts all CTs from the selected split
+    - clears config.processed_ct_dir
     - preprocesses all CTs
     - saves processed CT tensors to config.processed_ct_dir
 
@@ -192,6 +194,9 @@ def prepare_test_data(
 
     FileNotFoundError
         If required CT files do not exist.
+
+    OSError
+        If the processed CT output directory cannot be cleared.
     """
 
     data_dict = create_data_split_dict(
@@ -224,6 +229,8 @@ def prepare_test_data(
         raise ValueError(
             f"The {config.evaluation_split} split is empty. Cannot prepare MAISI {config.evaluation_split} data"
         )
+
+    clear_directory_contents(config.processed_ct_dir)
 
     process_and_save_cts(
         config=config,

--- a/src/pipeline/evaluation/metrics.py
+++ b/src/pipeline/evaluation/metrics.py
@@ -8,6 +8,7 @@ from src.pipeline.evaluation.image_metrics import (
     calculate_similarity_metrics,
 )
 from src.pipeline.evaluation.structure_metrics import calculate_structure_similarity_metrics
+from src.pipeline.helpers.cleanup import clear_directory_contents
 from src.pipeline.helpers.helpers import (
     _build_lpips_model,
     _clean_pipeline_memory,
@@ -167,6 +168,9 @@ def evaluate_generated_cts(
     2. generated_pairwise_variety_metrics.csv
        Generated CT variants compared with each other.
 
+    The metrics output directory is cleared before new CSV files are written.
+    Generated CTs and processed reference CTs are left untouched.
+
     The goal is to check:
     - whether generated CTs are similar to real CTs
     - whether generated variants are diverse relative to each other
@@ -186,7 +190,12 @@ def evaluate_generated_cts(
 
     ValueError
         If no valid generated-vs-real comparisons can be calculated.
+
+    OSError
+        If the metrics output directory cannot be cleared.
     """
+
+    clear_directory_contents(config.metrics_dir)
 
     generated = collect_generated_cts(config.generated_ct_dir)
     originals = collect_original_cts(config.processed_ct_dir)

--- a/src/pipeline/helpers/cleanup.py
+++ b/src/pipeline/helpers/cleanup.py
@@ -1,0 +1,36 @@
+import shutil
+from pathlib import Path
+
+
+def clear_directory_contents(directory: Path) -> None:
+    """
+    Delete every item inside an output directory while preserving the directory.
+
+    Pipeline stages use this helper at the beginning of their public entry
+    points so repeated runs do not mix new outputs with leftovers from earlier
+    runs. The directory itself is retained because downstream code writes to
+    the configured path directly.
+
+    Symbolic links are treated as files and unlinked rather than traversed.
+    Real subdirectories are removed recursively.
+
+    Parameters
+    ----------
+    directory : Path
+        Directory whose contents should be removed. The path is created if it
+        does not already exist.
+
+    Raises
+    ------
+    OSError
+        If the directory cannot be created, or if one of its contents cannot be
+        removed because of permissions, locks, or another filesystem error.
+    """
+
+    directory.mkdir(parents=True, exist_ok=True)
+
+    for item in directory.iterdir():
+        if item.is_dir() and not item.is_symlink():
+            shutil.rmtree(item)
+        else:
+            item.unlink()

--- a/src/pipeline/inference/encode_latents.py
+++ b/src/pipeline/inference/encode_latents.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 from src.data_utils import LoadProcessedTensord, sliding_window_inference
 from src.pipeline.config import MaisiTestingConfig
+from src.pipeline.helpers.cleanup import clear_directory_contents
 from src.pipeline.helpers.helpers import _clean_pipeline_memory
 
 
@@ -170,6 +171,7 @@ def encode_latents(config: MaisiTestingConfig) -> None:
     Encode processed planning CTs into latent representations using MAISI VAE.
 
     This function:
+    - clears `config.latent_ct_dir`
     - loads the pretrained MAISI VAE
     - loads processed planning CT tensors from `config.processed_ct_dir`
     - applies sliding-window VAE encoding
@@ -199,11 +201,14 @@ def encode_latents(config: MaisiTestingConfig) -> None:
 
     RuntimeError
         If the VAE checkpoint is incompatible with the VAE config.
+
+    OSError
+        If the latent CT output directory cannot be cleared.
     """
 
     device = torch.device(config.device)
 
-    config.latent_ct_dir.mkdir(parents=True, exist_ok=True)
+    clear_directory_contents(config.latent_ct_dir)
 
     vae_model = load_vae_model(
         config=config,

--- a/src/pipeline/inference/run_generation.py
+++ b/src/pipeline/inference/run_generation.py
@@ -19,6 +19,7 @@ from tqdm import tqdm
 
 from src.data_utils import sliding_window_inference
 from src.pipeline.config import MaisiTestingConfig
+from src.pipeline.helpers.cleanup import clear_directory_contents
 from src.pipeline.helpers.helpers import _clean_pipeline_memory
 from src.pipeline.inference.encode_latents import load_vae_model
 
@@ -232,6 +233,7 @@ def generate_ct_variants(config: MaisiTestingConfig) -> None:
     Generate CT variants from planning CT latent conditions.
 
     This function:
+    - clears `config.generated_ct_dir`
     - loads the VAE decoder
     - loads the rectified flow model
     - loads latent planning CT tensors from `config.latent_ct_dir`
@@ -260,6 +262,9 @@ def generate_ct_variants(config: MaisiTestingConfig) -> None:
     ------
     ValueError
         If scheduler config is missing required settings.
+
+    OSError
+        If the generated CT output directory cannot be cleared.
     """
 
     device = torch.device(config.device)
@@ -270,7 +275,7 @@ def generate_ct_variants(config: MaisiTestingConfig) -> None:
     if "base_img_size_numel" not in config.scheduler_config:
         raise ValueError("`config.scheduler_config` must contain 'base_img_size_numel'")
 
-    config.generated_ct_dir.mkdir(parents=True, exist_ok=True)
+    clear_directory_contents(config.generated_ct_dir)
 
     vae_model = load_vae_model(config, device)
     rflow_model = load_rflow_model(config, device)


### PR DESCRIPTION
## Description

Ensures that pipeline stage output directories are cleared before a stage begins execution to prevent stale results from previous runs from affecting current outputs. This preserves support for running individual pipeline stages while ensuring that each stage starts with a clean output directory.

## Related Issue

Closes #50 

## Proposed Changes

* Clears the contents of each stage's output directory before executing that stage.